### PR TITLE
yank verison of httpx to 0.24.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pySmartHashtag"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
     {"name" = "Bastian Neumann", "email" = "neumann.bastian@gmail.com"},
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-httpx
+httpx==0.24.1
 pycryptodome>=3.4
 pyjwt>=2.1.0


### PR DESCRIPTION
httpx 0.25 produces errors in url encoding following redirects. This issue blocked HA installations in docker to authenticate propperly.