### PR TITLE
Revert "Add international region support for Hello Smart app (Australia, Asia-Pacific)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,42 +15,6 @@ Get this custom integration into homeassistant
 
 [![Project Maintenance][maintenance-shield]](https://platinenmacher.tech)
 
-## Region Support
-
-The library supports both European and International (Asia-Pacific) regions. This is important for users with the **Hello Smart International** app (used in Australia, Singapore, and other international markets).
-
-### Usage
-
-```python
-from pysmarthashtag.account import SmartAccount
-from pysmarthashtag.const import SmartRegion, get_endpoint_urls_for_region
-
-# For European users (default)
-account = SmartAccount("user@example.com", "password")
-
-# For International/Asia-Pacific users (Australia, Singapore, etc.)
-endpoint_urls = get_endpoint_urls_for_region(SmartRegion.INTL)
-account = SmartAccount("user@example.com", "password", endpoint_urls=endpoint_urls)
-```
-
-### CLI Usage
-
-When using the command-line interface, you can specify the region with the `--region` flag:
-
-```bash
-# European region (default)
-python -m pysmarthashtag.cli --username user@example.com --password secret status
-
-# International region
-python -m pysmarthashtag.cli --username user@example.com --password secret --region intl status
-```
-
-You can also set the region via environment variable:
-
-```bash
-export SMART_REGION=intl
-```
-
 ## AI Disclosure
 
 This project uses AI to assist with development.

--- a/pysmarthashtag/__init__.py
+++ b/pysmarthashtag/__init__.py
@@ -2,13 +2,4 @@
 
 from importlib.metadata import version
 
-from pysmarthashtag.const import EndpointUrls, SmartRegion, get_endpoint_urls_for_region
-
 __version__ = version("pySmartHashtag")
-
-__all__ = [
-    "__version__",
-    "SmartRegion",
-    "EndpointUrls",
-    "get_endpoint_urls_for_region",
-]

--- a/pysmarthashtag/cli.py
+++ b/pysmarthashtag/cli.py
@@ -1,21 +1,14 @@
 #!/usr/bin/python3
 """Simple executable to demonstrate and test the usage of the library."""
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import logging.config
 import os
 import time
-from typing import TYPE_CHECKING
 
 from pysmarthashtag.account import SmartAccount
-from pysmarthashtag.const import SmartRegion, get_endpoint_urls_for_region
 from pysmarthashtag.control.climate import HeatingLocation
-
-if TYPE_CHECKING:
-    from pysmarthashtag.const import EndpointUrls
 
 
 def environ_or_required(key):
@@ -104,8 +97,7 @@ async def parse_command(args) -> None:
 
 async def get_status(args) -> None:
     """Get status of vehicle."""
-    endpoint_urls = _get_endpoint_urls_from_args(args)
-    account = SmartAccount(args.username, args.password, endpoint_urls=endpoint_urls)
+    account = SmartAccount(args.username, args.password)
     await account.get_vehicles()
 
     for vin, vehicle in account.vehicles.items():
@@ -114,8 +106,7 @@ async def get_status(args) -> None:
 
 async def get_vehicle_information(args) -> None:
     """Get status of vehicle."""
-    endpoint_urls = _get_endpoint_urls_from_args(args)
-    account = SmartAccount(args.username, args.password, endpoint_urls=endpoint_urls)
+    account = SmartAccount(args.username, args.password)
     await account.get_vehicles()
 
     for vin, _ in account.vehicles.items():
@@ -126,8 +117,7 @@ async def get_vehicle_information(args) -> None:
 
 async def watch_car(args) -> None:
     """Get status of vehicle."""
-    endpoint_urls = _get_endpoint_urls_from_args(args)
-    account = SmartAccount(args.username, args.password, endpoint_urls=endpoint_urls)
+    account = SmartAccount(args.username, args.password)
     await account.get_vehicles()
 
     while True:
@@ -139,8 +129,7 @@ async def watch_car(args) -> None:
 
 async def set_climate(args) -> None:
     """Set climate of vehicle."""
-    endpoint_urls = _get_endpoint_urls_from_args(args)
-    account = SmartAccount(args.username, args.password, endpoint_urls=endpoint_urls)
+    account = SmartAccount(args.username, args.password)
     await account.get_vehicles()
     if not args.vin:
         args.vin = list(account.vehicles.keys())[0]
@@ -152,8 +141,7 @@ async def set_climate(args) -> None:
 
 async def set_seatheating(args) -> None:
     """Set heating of driver's seat in vehicle."""
-    endpoint_urls = _get_endpoint_urls_from_args(args)
-    account = SmartAccount(args.username, args.password, endpoint_urls=endpoint_urls)
+    account = SmartAccount(args.username, args.password)
     await account.get_vehicles()
     if not args.vin:
         args.vin = list(account.vehicles.keys())[0]
@@ -168,26 +156,6 @@ def _add_default_args(parser: argparse.ArgumentParser):
     """Add the default arguments username, password to the parser."""
     parser.add_argument("--username", help="Smart username", **environ_or_required("SMART_USERNAME"))
     parser.add_argument("--password", help="Smart password", **environ_or_required("SMART_PASSWORD"))
-    parser.add_argument(
-        "--region",
-        help="Region for Smart API (eu=Europe, intl=International/Australia/Asia-Pacific)",
-        choices=["eu", "intl"],
-        default=os.environ.get("SMART_REGION", "eu"),
-    )
-
-
-def _get_endpoint_urls_from_args(args) -> EndpointUrls:
-    """Get EndpointUrls based on region argument.
-
-    Args:
-        args: Parsed command line arguments containing the region.
-
-    Returns:
-        EndpointUrls configured for the specified region.
-
-    """
-    region = SmartRegion(args.region)
-    return get_endpoint_urls_for_region(region)
 
 
 def main():

--- a/pysmarthashtag/const.py
+++ b/pysmarthashtag/const.py
@@ -1,7 +1,6 @@
 """URLs for different services and error code mapping."""
 
 from dataclasses import dataclass
-from enum import Enum
 from typing import Optional
 
 API_KEY = "3_L94eyQ-wvJhWm7Afp1oBhfTGXZArUfSHHW9p9Pncg513hZELXsxCfMWHrF8f5P5a"
@@ -18,55 +17,6 @@ API_TELEMATICS_URL = "/remote-control/vehicle/telematics/"
 OTA_SERVER_URL = "https://ota.srv.smart.com/"
 
 HTTPX_TIMEOUT = 30.0
-
-
-class SmartRegion(str, Enum):
-    """Region presets for Smart API endpoints.
-
-    Use these region presets to easily configure the API for different geographic regions.
-    - EU: European region (default) - for users with Hello Smart EU app
-    - INTL: International region (Asia-Pacific) - for users with Hello Smart International app
-           (Australia, Singapore, and other international markets)
-    """
-
-    EU = "eu"
-    INTL = "intl"
-
-
-def get_endpoint_urls_for_region(region: SmartRegion) -> "EndpointUrls":
-    """Get pre-configured EndpointUrls for a specific region.
-
-    Args:
-        region: The region to get endpoint URLs for.
-
-    Returns:
-        EndpointUrls configured for the specified region.
-
-    Example:
-        >>> from pysmarthashtag.const import SmartRegion, get_endpoint_urls_for_region
-        >>> from pysmarthashtag.account import SmartAccount
-        >>>
-        >>> # For Australian/International users
-        >>> endpoint_urls = get_endpoint_urls_for_region(SmartRegion.INTL)
-        >>> account = SmartAccount("user@example.com", "password", endpoint_urls=endpoint_urls)
-        >>>
-        >>> # For European users (default)
-        >>> endpoint_urls = get_endpoint_urls_for_region(SmartRegion.EU)
-        >>> account = SmartAccount("user@example.com", "password", endpoint_urls=endpoint_urls)
-
-    """
-    if region == SmartRegion.EU:
-        # European region - uses default endpoints
-        return EndpointUrls()
-    elif region == SmartRegion.INTL:
-        # International region (Asia-Pacific) - for Hello Smart International app
-        # Used in Australia, Singapore, and other international markets
-        return EndpointUrls(
-            api_base_url="https://api.ecloudap.com",
-            api_base_url_v2="https://apiv2.ecloudap.com",
-        )
-    else:
-        raise ValueError(f"Unknown region: {region}")
 
 
 @dataclass

--- a/pysmarthashtag/tests/test_endpoint_urls.py
+++ b/pysmarthashtag/tests/test_endpoint_urls.py
@@ -13,8 +13,6 @@ from pysmarthashtag.const import (
     OTA_SERVER_URL,
     SERVER_URL,
     EndpointUrls,
-    SmartRegion,
-    get_endpoint_urls_for_region,
 )
 from pysmarthashtag.tests import TEST_PASSWORD, TEST_USERNAME
 from pysmarthashtag.tests.conftest import prepare_account_with_vehicles
@@ -172,64 +170,3 @@ async def test_account_with_explicit_default_urls(smart_fixture: respx.Router):
     await account.get_vehicles()
     assert account is not None
     assert len(account.vehicles) == 2
-
-
-class TestSmartRegion:
-    """Test SmartRegion enum and get_endpoint_urls_for_region function."""
-
-    def test_region_eu_returns_default_endpoints(self):
-        """Test that EU region returns default (European) endpoints."""
-        urls = get_endpoint_urls_for_region(SmartRegion.EU)
-        assert urls.get_api_base_url() == API_BASE_URL
-        assert urls.get_api_base_url_v2() == "https://apiv2.ecloudeu.com"
-        assert urls.get_server_url() == SERVER_URL
-        assert urls.get_login_url() == LOGIN_URL
-        assert urls.get_auth_url() == AUTH_URL
-        assert urls.get_ota_server_url() == OTA_SERVER_URL
-
-    def test_region_intl_returns_asia_pacific_endpoints(self):
-        """Test that INTL region returns Asia-Pacific endpoints for international users."""
-        urls = get_endpoint_urls_for_region(SmartRegion.INTL)
-        # International region uses Asia-Pacific cloud endpoints
-        assert urls.get_api_base_url() == "https://api.ecloudap.com"
-        assert urls.get_api_base_url_v2() == "https://apiv2.ecloudap.com"
-        # Other endpoints remain default (shared infrastructure)
-        assert urls.get_server_url() == SERVER_URL
-        assert urls.get_login_url() == LOGIN_URL
-        assert urls.get_auth_url() == AUTH_URL
-
-    def test_region_enum_values(self):
-        """Test that SmartRegion enum has expected values."""
-        assert SmartRegion.EU.value == "eu"
-        assert SmartRegion.INTL.value == "intl"
-
-    def test_account_with_eu_region(self):
-        """Test creating SmartAccount with EU region preset."""
-        urls = get_endpoint_urls_for_region(SmartRegion.EU)
-        account = SmartAccount(
-            username="test@example.com",
-            password="testpass",
-            endpoint_urls=urls,
-        )
-        assert account.endpoint_urls.get_api_base_url() == API_BASE_URL
-
-    def test_account_with_intl_region(self):
-        """Test creating SmartAccount with INTL region preset."""
-        urls = get_endpoint_urls_for_region(SmartRegion.INTL)
-        account = SmartAccount(
-            username="test@example.com",
-            password="testpass",
-            endpoint_urls=urls,
-        )
-        assert account.endpoint_urls.get_api_base_url() == "https://api.ecloudap.com"
-        assert account.endpoint_urls.get_api_base_url_v2() == "https://apiv2.ecloudap.com"
-
-    def test_authentication_with_intl_region(self):
-        """Test SmartAuthentication with INTL region preset."""
-        urls = get_endpoint_urls_for_region(SmartRegion.INTL)
-        auth = SmartAuthentication(
-            username="test@example.com",
-            password="testpass",
-            endpoint_urls=urls,
-        )
-        assert auth.endpoint_urls.get_api_base_url() == "https://api.ecloudap.com"


### PR DESCRIPTION
Reverts DasBasti/pySmartHashtag#150

The function did not solve the seperate login mechanism

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed regional support and the `--region` CLI argument
  * Updated endpoint configuration approach with new getter methods

* **Documentation**
  * Removed region support section from README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->