### PR TITLE
chore: include Smart #5 in project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CodeQL Validation][codeql-shield]][codeql]
 [![Dependency Validation][tests-shield]][tests]
 
-API wrapper for Smart #1 and #3 Cloud Service
+API wrapper for Smart #1, #3 and #5 Cloud Service
 
 Regard this to be kind of stable. This library is used in custom [Homeassistant](https://homeassistant.io) component [Smart Hashtag](https://github.com/DasBasti/SmartHashtag)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [
     {"name" = "Bastian Neumann", "email" = "neumann.bastian@gmail.com"},
 ]
-description = "A python library to get information from Smart #1 and #3 web API"
+description = "A python library to get information from Smart #1, #3 and #5 web API"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Two-line cosmetic refresh: the user-facing description in `README.md` and `pyproject.toml` still mentions only Smart #1 and #3, but the library has supported Smart #5 (HY-series VINs) since the V2 API host branch landed (`vehicle.py:81-89` already routes #5 to `API_BASE_URL_V2`).

This makes the description match reality so HACS / PyPI scrapers don't under-report the project's scope.

## Test plan

- [x] No code changes — pure description edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated library description and metadata to indicate support for Smart #5 Cloud Service alongside Smart #1 and #3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->