### PR TITLE
feat(journal): add trip journal endpoint + recording enable/disable

### DIFF
--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -41,6 +41,15 @@ class SmartAccount:
     vehicles: dict[str, SmartVehicle] = field(default_factory=dict, init=False)
     """Vehicles associated with the account."""
 
+    _journal_grant_cache: dict[str, str] = field(default_factory=dict, init=False)
+    """Per-VIN cache of the access_token under which the trip-journal
+    authorization grant was last accepted. ``{vin: access_token_string}``.
+    Used to skip the redundant grant POST when the same token is still
+    valid; auto-invalidates as soon as the token rotates (any reason —
+    expiry, manual relogin, future refresh-token flow). Maintained by
+    :meth:`grant_journal_authorization`.
+    """
+
     def __post_init__(self, password, log_responses):
         """Initialize the account."""
         # Ensure endpoint_urls is set
@@ -272,19 +281,42 @@ class SmartAccount:
                 raise SmartAuthError("Could not get vehicle information")
         return data
 
-    async def grant_journal_authorization(self, vin) -> bool:
+    async def grant_journal_authorization(self, vin, force: bool = False) -> bool:
         """Grant cloud-side authorization for trip-journal data access.
 
         ``POST /remote-control/user/authorization/insert`` with
         ``{"serviceCode": "travelLogBusiCode", "authStatus": 1, "vin": <vin>}``.
-        This is a one-time-per-session handshake that unlocks the
-        journalLogV4 endpoint — without it, journalLogV4 returns
-        ``code: 8153`` ("data unavailable") even on vehicles where the
-        on-vehicle recording flag is set and trip data exists cloud-side.
+        This is a per-session handshake that unlocks the journalLogV4
+        endpoint — without it, journalLogV4 returns ``code: 8153``
+        ("data unavailable") even on vehicles where the on-vehicle
+        recording flag is set and trip data exists cloud-side.
 
-        Idempotent: re-issuing always succeeds, so calling it on every
-        ``get_trip_journal`` invocation is safe and small overhead.
+        Cached per-VIN per-access-token. The grant POST is observed to
+        rotate the access_token server-side (every poll without the cache
+        returns ``1402 token invalid`` on the next call, forcing a
+        re-login). The cache stores the access_token under which the
+        grant was accepted; subsequent calls under the *same* token
+        skip the redundant POST. The cache auto-invalidates as soon as
+        the token rotates (relogin, refresh, expiry — any reason).
+
+        Args:
+            vin: Vehicle identification number.
+            force: If True, ignore the cache and re-issue the grant.
+                Use this for explicit init flows where you want to be
+                certain the grant is fresh.
+
+        Returns:
+            True if the grant succeeded (or was already cached);
+            False if the POST failed.
         """
+        token = self.config.authentication.api_access_token
+        if not force and token and self._journal_grant_cache.get(vin) == token:
+            _LOGGER.debug(
+                "Journal authorization cached for %s under current token; skipping POST",
+                vin,
+            )
+            return True
+
         _LOGGER.debug("Granting journal authorization for %s", vin)
         path = "/remote-control/user/authorization/insert"
         body = json.dumps({"serviceCode": "travelLogBusiCode", "authStatus": 1, "vin": vin})
@@ -306,7 +338,15 @@ class SmartAccount:
                         content=body.encode("utf-8"),
                     )
                     payload = r.json()
-                    return bool(payload.get("success") or payload.get("code") == "1000")
+                    success = bool(payload.get("success") or payload.get("code") == "1000")
+                    if success:
+                        # Record the token under which this grant was accepted.
+                        # Re-read after the POST since the server may have rotated
+                        # it during the call.
+                        self._journal_grant_cache[vin] = (
+                            self.config.authentication.api_access_token
+                        )
+                    return success
                 except SmartTokenRefreshNecessary:
                     _LOGGER.debug("Token refresh needed during auth-grant retry %d", retry)
                     continue
@@ -326,9 +366,11 @@ class SmartAccount:
 
         Sends ``startTime`` / ``endTime`` (ms-epoch window), ``pageIndex``,
         ``pageSize``, and ``userId`` as query params. The endpoint requires
-        a one-time-per-session authorization grant
+        a per-session authorization grant
         (:meth:`grant_journal_authorization`), which this method calls
-        first; without it the endpoint returns ``code: 8153``.
+        first; without it the endpoint returns ``code: 8153``. The grant
+        is cached per-VIN per-access-token, so subsequent calls under the
+        same token skip the grant POST.
 
         Returns the raw response dict (with ``code``/``message``/``data``)
         or an empty dict when the request fails server-side; raising is

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -308,6 +308,7 @@ class SmartAccount:
         Returns:
             True if the grant succeeded (or was already cached);
             False if the POST failed.
+
         """
         token = self.config.authentication.api_access_token
         if not force and token and self._journal_grant_cache.get(vin) == token:

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -151,8 +151,10 @@ class SmartAccount:
             journal_response = None
             try:
                 journal_response = await self.get_trip_journal(vin)
-            except Exception:
-                _LOGGER.debug("Trip journal fetch failed for %s", vin, exc_info=True)
+            except Exception:  # noqa: BLE001  # Best-effort: any failure (8153, transport, parse) must not break refresh.
+                _LOGGER.debug(
+                    "Trip journal fetch failed for %s", sanitize_log_data(vin), exc_info=True
+                )
             vehicle.combine_data(
                 vehicle_info,
                 charging_settings=vehicle_soc,
@@ -314,11 +316,11 @@ class SmartAccount:
         if not force and token and self._journal_grant_cache.get(vin) == token:
             _LOGGER.debug(
                 "Journal authorization cached for %s under current token; skipping POST",
-                vin,
+                sanitize_log_data(vin),
             )
             return True
 
-        _LOGGER.debug("Granting journal authorization for %s", vin)
+        _LOGGER.debug("Granting journal authorization for %s", sanitize_log_data(vin))
         path = "/remote-control/user/authorization/insert"
         body = json.dumps({"serviceCode": "travelLogBusiCode", "authStatus": 1, "vin": vin})
         async with SmartClient(self.config) as client:

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -134,7 +134,22 @@ class SmartAccount:
             vehicle_info = await self.get_vehicle_information(vin)
             vehicle_soc = await self.get_vehicle_soc(vin)
             vehicle_ota_info = await self.get_vehicle_ota_info(vin)
-            vehicle.combine_data(vehicle_info, charging_settings=vehicle_soc, ota_info=vehicle_ota_info)
+            # Trip journal is best-effort: the endpoint can return 8153
+            # ("data unavailable") on vehicles where on-vehicle trip
+            # recording is OFF, or transiently when the per-session auth
+            # grant hasn't been accepted yet. Never let an empty journal
+            # fail the whole refresh.
+            journal_response = None
+            try:
+                journal_response = await self.get_trip_journal(vin)
+            except Exception:
+                _LOGGER.debug("Trip journal fetch failed for %s", vin, exc_info=True)
+            vehicle.combine_data(
+                vehicle_info,
+                charging_settings=vehicle_soc,
+                ota_info=vehicle_ota_info,
+                journal_response=journal_response,
+            )
 
     async def select_active_vehicle(self, vin) -> None:
         """Select the active vehicle."""
@@ -255,6 +270,109 @@ class SmartAccount:
                 break
             if retry > 1:
                 raise SmartAuthError("Could not get vehicle information")
+        return data
+
+    async def grant_journal_authorization(self, vin) -> bool:
+        """Grant cloud-side authorization for trip-journal data access.
+
+        ``POST /remote-control/user/authorization/insert`` with
+        ``{"serviceCode": "travelLogBusiCode", "authStatus": 1, "vin": <vin>}``.
+        This is a one-time-per-session handshake that unlocks the
+        journalLogV4 endpoint — without it, journalLogV4 returns
+        ``code: 8153`` ("data unavailable") even on vehicles where the
+        on-vehicle recording flag is set and trip data exists cloud-side.
+
+        Idempotent: re-issuing always succeeds, so calling it on every
+        ``get_trip_journal`` invocation is safe and small overhead.
+        """
+        _LOGGER.debug("Granting journal authorization for %s", vin)
+        path = "/remote-control/user/authorization/insert"
+        body = json.dumps({"serviceCode": "travelLogBusiCode", "authStatus": 1, "vin": vin})
+        async with SmartClient(self.config) as client:
+            for retry in range(3):
+                try:
+                    r = await client.post(
+                        self.vehicles[vin].base_url + path,
+                        headers={
+                            **utils.generate_default_header(
+                                client.config.authentication.device_id,
+                                client.config.authentication.api_access_token,
+                                params={},
+                                method="POST",
+                                url=path,
+                                body=body,
+                            )
+                        },
+                        content=body.encode("utf-8"),
+                    )
+                    payload = r.json()
+                    return bool(payload.get("success") or payload.get("code") == "1000")
+                except SmartTokenRefreshNecessary:
+                    _LOGGER.debug("Token refresh needed during auth-grant retry %d", retry)
+                    continue
+                except SmartHumanCarConnectionError:
+                    _LOGGER.debug("Human-car connection error during auth-grant retry %d", retry)
+                    await self.select_active_vehicle(vin)
+                    continue
+                break
+        return False
+
+    async def get_trip_journal(self, vin, page_size: int = 20, window_days: int = 14) -> dict:
+        """Fetch the most recent trip-journal entries for a vehicle.
+
+        Hits ``/geelyTCAccess/tcservices/vehicle/status/journalLogV4/{vin}``
+        — the endpoint that carries server-side reverse-geocoded start/end
+        addresses alongside per-trip energy/distance/speed metrics.
+
+        Sends ``startTime`` / ``endTime`` (ms-epoch window), ``pageIndex``,
+        ``pageSize``, and ``userId`` as query params. The endpoint requires
+        a one-time-per-session authorization grant
+        (:meth:`grant_journal_authorization`), which this method calls
+        first; without it the endpoint returns ``code: 8153``.
+
+        Returns the raw response dict (with ``code``/``message``/``data``)
+        or an empty dict when the request fails server-side; raising is
+        avoided so a single flaky vehicle doesn't break the whole refresh.
+        """
+        await self.grant_journal_authorization(vin)
+        _LOGGER.debug("Getting trip journal for vehicle")
+        end_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+        start_ms = end_ms - window_days * 86400 * 1000
+        params = {
+            "endTime": str(end_ms),
+            "pageIndex": "1",
+            "pageSize": str(page_size),
+            "startTime": str(start_ms),
+            "userId": str(self.config.authentication.api_user_id),
+        }
+        path = "/geelyTCAccess/tcservices/vehicle/status/journalLogV4/" + vin
+        url = path + "?" + utils.join_url_params(params)
+        data: dict = {}
+        async with SmartClient(self.config) as client:
+            for retry in range(3):
+                try:
+                    r_journal = await client.get(
+                        self.vehicles[vin].base_url + url,
+                        headers={
+                            **utils.generate_default_header(
+                                client.config.authentication.device_id,
+                                client.config.authentication.api_access_token,
+                                params=params,
+                                method="GET",
+                                url=path,
+                            )
+                        },
+                    )
+                    _LOGGER.debug("Got response %d", r_journal.status_code)
+                    data = r_journal.json()
+                except SmartTokenRefreshNecessary:
+                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    continue
+                except SmartHumanCarConnectionError:
+                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                    await self.select_active_vehicle(vin)
+                    continue
+                break
         return data
 
     async def get_vehicle_ota_info(self, vin) -> dict:

--- a/pysmarthashtag/const.py
+++ b/pysmarthashtag/const.py
@@ -13,6 +13,7 @@ API_CARS_URL = "/device-platform/user/vehicle/secure"
 API_SESION_URL = "/auth/account/session/secure"
 API_SELECT_CAR_URL = "/device-platform/user/session/update"
 API_TELEMATICS_URL = "/remote-control/vehicle/telematics/"
+API_JOURNAL_TOGGLE_URL = "/remote-control/vehicle/status/journalLog/"
 
 OTA_SERVER_URL = "https://ota.srv.smart.com/"
 

--- a/pysmarthashtag/control/journal.py
+++ b/pysmarthashtag/control/journal.py
@@ -47,7 +47,7 @@ class JournalRecordingControl:
                 "duration": 60,
             },
         }
-        return json.dumps(payload).replace(" ", "")
+        return json.dumps(payload, separators=(",", ":"))
 
     async def enable_recording(self) -> bool:
         """Turn on-vehicle trip recording ON."""
@@ -90,5 +90,6 @@ class JournalRecordingControl:
                     continue
                 except SmartHumanCarConnectionError:
                     _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                    await self.account.select_active_vehicle(self.vin)
                     continue
         return False

--- a/pysmarthashtag/control/journal.py
+++ b/pysmarthashtag/control/journal.py
@@ -1,0 +1,94 @@
+"""Provides client-side control of the vehicle's on-vehicle trip-recording flag.
+
+When the flag is OFF, the vehicle's TBox does not write to the cloud-side
+journal log, so ``SmartAccount.get_trip_journal()`` returns ``code:8153``
+"data unavailable". Toggling the flag ON causes subsequent trips to be
+written to the journal log, after which ``get_trip_journal()`` returns
+populated trip records.
+
+Modeled on ``pysmarthashtag.control.charging.ChargingControl``.
+"""
+
+import json
+import logging
+
+from pysmarthashtag.account import SmartAccount
+from pysmarthashtag.api import utils
+from pysmarthashtag.api.client import SmartClient
+from pysmarthashtag.const import API_JOURNAL_TOGGLE_URL
+from pysmarthashtag.models import SmartHumanCarConnectionError, SmartTokenRefreshNecessary
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class JournalRecordingControl:
+    """Toggle the on-vehicle trip-recording flag (``journalLogState``)."""
+
+    def __init__(self, account: SmartAccount, vin: str):
+        self.account = account
+        self.config = account.config
+        self.vin = vin
+
+    def _get_payload(self, enable: bool) -> str:
+        payload = {
+            "creator": "tc",
+            "timestamp": utils.create_correct_timestamp(),
+            "latest": False,
+            "command": "start" if enable else "stop",
+            "serviceId": "JOU",
+            "serviceParameters": [
+                {"key": "jou", "value": "enable" if enable else "disable"},
+            ],
+            "operationScheduling": {
+                "scheduledTime": 0,
+                "interval": 0,
+                "occurs": 0,
+                "recurrentOperation": True,
+                "duration": 60,
+            },
+        }
+        return json.dumps(payload).replace(" ", "")
+
+    async def enable_recording(self) -> bool:
+        """Turn on-vehicle trip recording ON."""
+        return await self._set_recording(enable=True)
+
+    async def disable_recording(self) -> bool:
+        """Turn on-vehicle trip recording OFF."""
+        return await self._set_recording(enable=False)
+
+    async def _set_recording(self, enable: bool) -> bool:
+        await self.account._ensure_ssl_context()
+        await self.account.select_active_vehicle(self.vin)
+
+        path = API_JOURNAL_TOGGLE_URL + self.vin
+        body = self._get_payload(enable)
+        action = "enable" if enable else "disable"
+        _LOGGER.debug("Setting trip-recording: %s", action)
+
+        async with SmartClient(self.config) as client:
+            for retry in range(3):
+                try:
+                    response = await client.put(
+                        self.account.vehicles[self.vin].base_url + path,
+                        headers={
+                            **utils.generate_default_header(
+                                client.config.authentication.device_id,
+                                client.config.authentication.api_access_token,
+                                params={},
+                                method="PUT",
+                                url=path,
+                                body=body,
+                            )
+                        },
+                        content=body.encode("utf-8"),
+                    )
+                    api_result = response.json()
+                    return bool(api_result.get("success"))
+                except SmartTokenRefreshNecessary:
+                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    continue
+                except SmartHumanCarConnectionError:
+                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                    continue
+        return False

--- a/pysmarthashtag/tests/common.py
+++ b/pysmarthashtag/tests/common.py
@@ -1,5 +1,7 @@
 """Fixtures for Smart tests."""
 
+import re
+
 import respx
 
 from pysmarthashtag.const import (
@@ -109,7 +111,6 @@ class SmartMockRouter(respx.MockRouter):
             # query params; respx matches by URL prefix without query when
             # we use route() with `host=` + `path__startswith=`. Keep
             # URL-prefix matching simple by registering with a regex.
-            import re
             self.get(re.compile(re.escape(
                 base_url + "/geelyTCAccess/tcservices/vehicle/status/journalLogV4/TestVIN0000000001"
             ) + r".*")).respond(

--- a/pysmarthashtag/tests/common.py
+++ b/pysmarthashtag/tests/common.py
@@ -132,6 +132,14 @@ class SmartMockRouter(respx.MockRouter):
                     "message": "operation succeed",
                 },
             )
+            self.put(base_url + "/remote-control/vehicle/status/journalLog/TestVIN0000000001").respond(
+                200,
+                json=load_response(RESPONSE_DIR / "journal_toggle_success.json"),
+            )
+            self.put(base_url + "/remote-control/vehicle/status/journalLog/TestVIN0000000002").respond(
+                200,
+                json=load_response(RESPONSE_DIR / "journal_toggle_success.json"),
+            )
 
         self.get(OTA_SERVER_URL + "app/info/TestVIN0000000001").respond(
             200,

--- a/pysmarthashtag/tests/common.py
+++ b/pysmarthashtag/tests/common.py
@@ -105,6 +105,33 @@ class SmartMockRouter(respx.MockRouter):
                 200,
                 json=load_response(RESPONSE_DIR / "soc_90.json"),
             )
+            # journalLogV4 takes endTime/startTime/pageIndex/pageSize/userId
+            # query params; respx matches by URL prefix without query when
+            # we use route() with `host=` + `path__startswith=`. Keep
+            # URL-prefix matching simple by registering with a regex.
+            import re
+            self.get(re.compile(re.escape(
+                base_url + "/geelyTCAccess/tcservices/vehicle/status/journalLogV4/TestVIN0000000001"
+            ) + r".*")).respond(
+                200,
+                json=load_response(RESPONSE_DIR / "journal_response.json"),
+            )
+            self.get(re.compile(re.escape(
+                base_url + "/geelyTCAccess/tcservices/vehicle/status/journalLogV4/TestVIN0000000002"
+            ) + r".*")).respond(
+                200,
+                json=load_response(RESPONSE_DIR / "journal_response.json"),
+            )
+            # Auth-grant handshake (called before each get_trip_journal)
+            self.post(base_url + "/remote-control/user/authorization/insert").respond(
+                200,
+                json={
+                    "code": "1000",
+                    "data": {"serviceCode": "travelLogBusiCode", "authStatus": 1},
+                    "success": True,
+                    "message": "operation succeed",
+                },
+            )
 
         self.get(OTA_SERVER_URL + "app/info/TestVIN0000000001").respond(
             200,

--- a/pysmarthashtag/tests/replys/journal_response.json
+++ b/pysmarthashtag/tests/replys/journal_response.json
@@ -1,0 +1,52 @@
+{
+  "code": "1000",
+  "message": "operation succeed",
+  "success": true,
+  "data": {
+    "pagination": {
+      "pageIndex": 1,
+      "sortField": "startTime",
+      "start": 1,
+      "pageSize": 20,
+      "totleSize": 42,
+      "direction": "desc"
+    },
+    "list": [
+      {
+        "tripId": 1734246000,
+        "startTime": 1734246000000,
+        "endTime": 1734247230000,
+        "startOdometer": 2950.0,
+        "endOdometer": 2965.4,
+        "traveledDistance": 15.4,
+        "avgSpeed": 45.0,
+        "electricConsumption": 20.8,
+        "tripStartAddr": "123 Test Street, Test City",
+        "tripEndAddr": "15 Other Road, Test City",
+        "tripRemark": null,
+        "tripLabel": null,
+        "trackpoints": [
+          {"position": {"altitude": 27, "latitude": 217414695, "longitude": 80626712, "posCanBeTrusted": true, "marsCoordinates": false}},
+          {"position": {"altitude": 28, "latitude": 217384510, "longitude": 80573036, "posCanBeTrusted": true, "marsCoordinates": false}}
+        ],
+        "regeneratedEnergy": 0.8
+      },
+      {
+        "tripId": 1734200000,
+        "startTime": 1734200000000,
+        "endTime": 1734200600000,
+        "startOdometer": 2942.9,
+        "endOdometer": 2950.0,
+        "traveledDistance": 7.1,
+        "avgSpeed": 40.0,
+        "electricConsumption": 21.1,
+        "tripStartAddr": "9 Elsewhere Ave, Test City",
+        "tripEndAddr": "123 Test Street, Test City",
+        "tripRemark": null,
+        "tripLabel": null,
+        "trackpoints": [],
+        "regeneratedEnergy": 0.3
+      }
+    ]
+  }
+}

--- a/pysmarthashtag/tests/replys/journal_toggle_success.json
+++ b/pysmarthashtag/tests/replys/journal_toggle_success.json
@@ -1,0 +1,9 @@
+{
+  "code": "1000",
+  "data": {},
+  "success": true,
+  "hint": null,
+  "httpStatus": "OK",
+  "sessionId": "test-session-journal-toggle",
+  "message": "operation succeed"
+}

--- a/pysmarthashtag/tests/test_journal.py
+++ b/pysmarthashtag/tests/test_journal.py
@@ -125,6 +125,55 @@ async def test_get_vehicles_populates_last_trip(smart_fixture: respx.Router):
 
 
 @pytest.mark.asyncio
+async def test_grant_authorization_caches_per_vin_token(smart_fixture: respx.Router):
+    """Repeated grant_journal_authorization calls under the same access_token
+    short-circuit on the cache; only the first call POSTs to the cloud.
+
+    The grant POST rotates the access_token server-side (observed empirically
+    against the live cloud). Without caching, every poll would burn 2x calls
+    (failed call + token-refresh + retry). The cache stores the token under
+    which the grant was accepted; subsequent calls under the *same* token
+    are no-ops; ``force=True`` bypasses; token rotation auto-invalidates.
+    """
+    account = await prepare_account_with_vehicles()
+    vin = "TestVIN0000000001"
+
+    # The mock router registered POST /authorization/insert during fixture
+    # setup; find it and count calls.
+    import re
+    insert_route = next(
+        r for r in smart_fixture.routes
+        if re.search(r"authorization/insert", str(r.pattern))
+        and "POST" in str(r.pattern)
+    )
+    insert_route.calls.reset()
+
+    # First call: should POST and cache.
+    ok = await account.grant_journal_authorization(vin)
+    assert ok is True
+    assert insert_route.calls.call_count == 1
+    cached_token = account._journal_grant_cache.get(vin)
+    assert cached_token is not None
+
+    # Second call under the same token: should NOT POST.
+    ok2 = await account.grant_journal_authorization(vin)
+    assert ok2 is True
+    assert insert_route.calls.call_count == 1, "second call should hit the cache"
+
+    # force=True bypasses the cache.
+    ok3 = await account.grant_journal_authorization(vin, force=True)
+    assert ok3 is True
+    assert insert_route.calls.call_count == 2, "force=True should re-POST"
+
+    # Manually rotate the token; cache should auto-invalidate on the
+    # next call (token mismatch in the lookup).
+    account.config.authentication.api_access_token = "rotated-token-xyz"
+    ok4 = await account.grant_journal_authorization(vin)
+    assert ok4 is True
+    assert insert_route.calls.call_count == 3, "token rotation should invalidate cache"
+
+
+@pytest.mark.asyncio
 async def test_get_vehicles_survives_journal_error(smart_fixture: respx.Router):
     """If journalLogV4 returns 8153 / etc., the rest of the refresh still works.
 

--- a/pysmarthashtag/tests/test_journal.py
+++ b/pysmarthashtag/tests/test_journal.py
@@ -126,8 +126,7 @@ async def test_get_vehicles_populates_last_trip(smart_fixture: respx.Router):
 
 @pytest.mark.asyncio
 async def test_grant_authorization_caches_per_vin_token(smart_fixture: respx.Router):
-    """Repeated grant_journal_authorization calls under the same access_token
-    short-circuit on the cache; only the first call POSTs to the cloud.
+    """Repeat-grant calls under the same access_token short-circuit via cache.
 
     The grant POST rotates the access_token server-side (observed empirically
     against the live cloud). Without caching, every poll would burn 2x calls

--- a/pysmarthashtag/tests/test_journal.py
+++ b/pysmarthashtag/tests/test_journal.py
@@ -1,0 +1,156 @@
+"""Tests for the trip journal endpoint and parser."""
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import respx
+
+from pysmarthashtag.const import API_BASE_URL, API_BASE_URL_V2
+from pysmarthashtag.tests import RESPONSE_DIR, load_response
+from pysmarthashtag.tests.conftest import prepare_account_with_vehicles
+from pysmarthashtag.vehicle.journal import TripJournal
+
+
+def test_from_response_handles_none():
+    """A None or non-dict input must not blow up."""
+    assert TripJournal.from_response(None) is None
+    assert TripJournal.from_response("not a dict") is None  # type: ignore[arg-type]
+
+
+def test_from_response_handles_empty_body():
+    """Empty body / missing data block returns None."""
+    assert TripJournal.from_response({}) is None
+    assert TripJournal.from_response({"code": 8153, "message": "Connection interruption"}) is None
+
+
+def test_from_response_handles_no_logs_with_total():
+    """Cloud reported a total but no logs — we still surface total_trips."""
+    parsed = TripJournal.from_response(
+        {"data": {"pagination": {"totleSize": 0}, "list": []}}
+    )
+    assert parsed is not None
+    assert parsed.total_trips == 0
+    assert parsed.trip_id == ""
+    assert parsed.start_address == ""
+
+
+def test_from_response_parses_full_record():
+    """All fields populate from the canonical response shape."""
+    parsed = TripJournal.from_response(load_response(RESPONSE_DIR / "journal_response.json"))
+    assert parsed is not None
+    # Cloud uses an int tripId; we coerce to string for stable consumer-side IDs.
+    assert parsed.trip_id == "1734246000"
+    assert parsed.distance.value == 15.4
+    assert parsed.distance.unit == "km"
+    # Duration is computed from start/end timestamps (cloud doesn't provide it).
+    assert parsed.duration == 1230  # (1734247230000 - 1734246000000) / 1000
+    # ``electricConsumption`` is the average (kWh/100km); we compute the
+    # absolute total as avg * distance / 100.
+    assert parsed.avg_energy_consumption.value == 20.8
+    assert parsed.avg_energy_consumption.unit == "kWh/100km"
+    assert parsed.energy_consumption.value == round(20.8 * 15.4 / 100, 3)
+    assert parsed.energy_consumption.unit == "kWh"
+    assert parsed.avg_speed.value == 45.0
+    # The cloud doesn't provide max_speed (would require trackpoint analysis).
+    assert parsed.max_speed is None
+    # Tz-aware UTC datetime (HA's TIMESTAMP device class needs tzinfo).
+    assert parsed.start_time == datetime.fromtimestamp(1734246000000 / 1000, tz=timezone.utc)
+    assert parsed.end_time == datetime.fromtimestamp(1734247230000 / 1000, tz=timezone.utc)
+    assert parsed.start_time.tzinfo is not None
+    assert parsed.regenerated_energy.value == 0.8
+    assert parsed.start_address == "123 Test Street, Test City"
+    assert parsed.end_address == "15 Other Road, Test City"
+    # Positions come from trackpoints[0] and trackpoints[-1] (raw int milliarcseconds).
+    assert parsed.start_position == (217414695, 80626712)
+    assert parsed.end_position == (217384510, 80573036)
+    assert parsed.total_trips == 42
+
+
+def test_from_response_handles_missing_optional_fields():
+    """Missing optional fields default to None, not crash."""
+    parsed = TripJournal.from_response(
+        {
+            "data": {
+                "pagination": {"totleSize": 1},
+                "list": [
+                    {
+                        "tripId": "minimal-trip",
+                        # All metric fields absent.
+                    }
+                ],
+            }
+        }
+    )
+    assert parsed is not None
+    assert parsed.trip_id == "minimal-trip"
+    assert parsed.distance is None
+    assert parsed.duration is None
+    assert parsed.energy_consumption is None
+    assert parsed.start_time is None
+    assert parsed.start_address == ""
+
+
+def test_from_response_handles_bogus_timestamp():
+    """A non-numeric startTime must not crash the parser."""
+    parsed = TripJournal.from_response(
+        {
+            "data": {
+                "pagination": {"totleSize": 1},
+                "list": [
+                    {
+                        "tripId": "broken-time",
+                        "startTime": "not-a-number",
+                        "endTime": None,
+                    }
+                ],
+            }
+        }
+    )
+    assert parsed is not None
+    assert parsed.start_time is None
+    assert parsed.end_time is None
+
+
+@pytest.mark.asyncio
+async def test_get_vehicles_populates_last_trip(smart_fixture: respx.Router):
+    """End-to-end: get_vehicles() → vehicle.last_trip is set from journalLogV4."""
+    account = await prepare_account_with_vehicles()
+    vehicle = account.vehicles["TestVIN0000000001"]
+    assert vehicle.last_trip is not None
+    assert vehicle.last_trip.trip_id == "1734246000"
+    assert vehicle.last_trip.start_address == "123 Test Street, Test City"
+    assert vehicle.last_trip.end_address == "15 Other Road, Test City"
+    assert vehicle.last_trip.total_trips == 42
+
+
+@pytest.mark.asyncio
+async def test_get_vehicles_survives_journal_error(smart_fixture: respx.Router):
+    """If journalLogV4 returns 8153 / etc., the rest of the refresh still works.
+
+    Override both VINs' journal routes via ``side_effect`` (the only way
+    respx reliably replaces a route registered by a prior fixture call).
+    """
+
+    def _error_response(_request):
+        # The SmartClient response hook compares ``code`` as a string.
+        return httpx.Response(
+            200,
+            json={"code": "8153", "message": "Connection interruption"},
+        )
+
+    import re
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        for vin in ("TestVIN0000000001", "TestVIN0000000002"):
+            # Override the regex route registered by SmartMockRouter (journalLogV4
+            # carries query params now, so the existing route is registered with
+            # a regex prefix); match that regex exactly so respx replaces it.
+            smart_fixture.get(re.compile(re.escape(
+                base + f"/geelyTCAccess/tcservices/vehicle/status/journalLogV4/{vin}"
+            ) + r".*")).mock(side_effect=_error_response)
+
+    account = await prepare_account_with_vehicles()
+    # Vehicles still loaded; just no last_trip populated.
+    assert len(account.vehicles) == 2
+    for vehicle in account.vehicles.values():
+        assert vehicle.last_trip is None

--- a/pysmarthashtag/tests/test_journal.py
+++ b/pysmarthashtag/tests/test_journal.py
@@ -112,6 +112,38 @@ def test_from_response_handles_bogus_timestamp():
     assert parsed.end_time is None
 
 
+def test_from_response_handles_non_list_payload_fields():
+    """Coerce non-list payload fields to empty list, never raise on indexing.
+
+    ``data.list`` and per-trip ``trackpoints`` could in principle drift to
+    non-list types in a future cloud schema; this guards against that.
+    """
+    # ``data.list`` is a dict (cloud schema drift) — parser returns None
+    # because there are no usable trip records, NOT a TypeError.
+    assert TripJournal.from_response({"data": {"list": {"unexpected": "shape"}}}) is None
+    # ``trackpoints`` is a string instead of a list — parser still returns
+    # the trip but with start/end positions = None.
+    parsed = TripJournal.from_response(
+        {
+            "data": {
+                "pagination": {"totleSize": 1},
+                "list": [
+                    {
+                        "tripId": "drift-trackpoints",
+                        "startTime": 1734246000000,
+                        "endTime": 1734247230000,
+                        "trackpoints": "not-a-list",
+                    }
+                ],
+            }
+        }
+    )
+    assert parsed is not None
+    assert parsed.trip_id == "drift-trackpoints"
+    assert parsed.start_position is None
+    assert parsed.end_position is None
+
+
 @pytest.mark.asyncio
 async def test_get_vehicles_populates_last_trip(smart_fixture: respx.Router):
     """End-to-end: get_vehicles() → vehicle.last_trip is set from journalLogV4."""

--- a/pysmarthashtag/tests/test_journal_control.py
+++ b/pysmarthashtag/tests/test_journal_control.py
@@ -23,10 +23,14 @@ async def test_enable_recording(smart_fixture: respx.Router):
     # Inspect the captured PUT body — find the route whose pattern includes
     # both the journalLog path and the PUT method.
     route = next(
-        r for r in smart_fixture.routes
-        if API_JOURNAL_TOGGLE_URL + "TestVIN0000000001" in str(r.pattern)
-        and "PUT" in str(r.pattern)
+        (
+            r for r in smart_fixture.routes
+            if API_JOURNAL_TOGGLE_URL + "TestVIN0000000001" in str(r.pattern)
+            and "PUT" in str(r.pattern)
+        ),
+        None,
     )
+    assert route is not None, "PUT route for journalLog/TestVIN0000000001 not found"
     sent = route.calls.last.request
     body = json.loads(sent.content.decode())
     assert body["command"] == "start"
@@ -49,10 +53,14 @@ async def test_disable_recording(smart_fixture: respx.Router):
     assert result is True
 
     route = next(
-        r for r in smart_fixture.routes
-        if API_JOURNAL_TOGGLE_URL + "TestVIN0000000001" in str(r.pattern)
-        and "PUT" in str(r.pattern)
+        (
+            r for r in smart_fixture.routes
+            if API_JOURNAL_TOGGLE_URL + "TestVIN0000000001" in str(r.pattern)
+            and "PUT" in str(r.pattern)
+        ),
+        None,
     )
+    assert route is not None, "PUT route for journalLog/TestVIN0000000001 not found"
     sent = route.calls.last.request
     body = json.loads(sent.content.decode())
     assert body["command"] == "stop"

--- a/pysmarthashtag/tests/test_journal_control.py
+++ b/pysmarthashtag/tests/test_journal_control.py
@@ -1,0 +1,59 @@
+"""Tests for the on-vehicle trip-recording toggle."""
+
+import json
+
+import pytest
+import respx
+
+from pysmarthashtag.const import API_JOURNAL_TOGGLE_URL
+from pysmarthashtag.tests.conftest import prepare_account_with_vehicles
+
+
+@pytest.mark.asyncio
+async def test_enable_recording(smart_fixture: respx.Router):
+    """Calling enable_recording PUTs the JOU-start envelope and returns True."""
+    account = await prepare_account_with_vehicles()
+    await account.get_vehicle_information("TestVIN0000000001")
+    ctrl = account.vehicles["TestVIN0000000001"].journal_recording_control
+    assert ctrl is not None
+
+    result = await ctrl.enable_recording()
+    assert result is True
+
+    # Inspect the captured PUT body — find the route whose pattern includes
+    # both the journalLog path and the PUT method.
+    route = next(
+        r for r in smart_fixture.routes
+        if API_JOURNAL_TOGGLE_URL + "TestVIN0000000001" in str(r.pattern)
+        and "PUT" in str(r.pattern)
+    )
+    sent = route.calls.last.request
+    body = json.loads(sent.content.decode())
+    assert body["command"] == "start"
+    assert body["serviceId"] == "JOU"
+    assert body["serviceParameters"] == [{"key": "jou", "value": "enable"}]
+    assert body["operationScheduling"]["recurrentOperation"] is True
+    assert body["operationScheduling"]["duration"] == 60
+    assert body["creator"] == "tc"
+    assert body["latest"] is False
+
+
+@pytest.mark.asyncio
+async def test_disable_recording(smart_fixture: respx.Router):
+    """Calling disable_recording PUTs the JOU-stop envelope and returns True."""
+    account = await prepare_account_with_vehicles()
+    await account.get_vehicle_information("TestVIN0000000001")
+    ctrl = account.vehicles["TestVIN0000000001"].journal_recording_control
+
+    result = await ctrl.disable_recording()
+    assert result is True
+
+    route = next(
+        r for r in smart_fixture.routes
+        if API_JOURNAL_TOGGLE_URL + "TestVIN0000000001" in str(r.pattern)
+        and "PUT" in str(r.pattern)
+    )
+    sent = route.calls.last.request
+    body = json.loads(sent.content.decode())
+    assert body["command"] == "stop"
+    assert body["serviceParameters"] == [{"key": "jou", "value": "disable"}]

--- a/pysmarthashtag/vehicle/journal.py
+++ b/pysmarthashtag/vehicle/journal.py
@@ -49,22 +49,22 @@ class TripJournal:
     trip_id: str = ""
     """Cloud-assigned trip identifier."""
 
-    distance: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    distance: Optional[ValueWithUnit] = None
     """Trip distance."""
 
     duration: Optional[int] = None
     """Trip duration in seconds (as the cloud reports it)."""
 
-    energy_consumption: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    energy_consumption: Optional[ValueWithUnit] = None
     """Total energy consumed during the trip."""
 
-    avg_energy_consumption: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    avg_energy_consumption: Optional[ValueWithUnit] = None
     """Average energy consumption (kWh / 100 km)."""
 
-    avg_speed: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    avg_speed: Optional[ValueWithUnit] = None
     """Average trip speed."""
 
-    max_speed: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    max_speed: Optional[ValueWithUnit] = None
     """Maximum trip speed."""
 
     start_time: Optional[datetime] = None
@@ -73,7 +73,7 @@ class TripJournal:
     end_time: Optional[datetime] = None
     """Trip end time."""
 
-    regenerated_energy: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    regenerated_energy: Optional[ValueWithUnit] = None
     """Energy recovered via regenerative braking."""
 
     start_address: str = ""

--- a/pysmarthashtag/vehicle/journal.py
+++ b/pysmarthashtag/vehicle/journal.py
@@ -1,0 +1,200 @@
+"""Trip journal models for pysmarthashtag.
+
+The Smart cloud exposes a per-vehicle trip log at
+``/geelyTCAccess/tcservices/vehicle/status/journalLogV4/{vin}`` whose
+response carries an array of trips with start/end timestamps, distances,
+energy figures, speeds, and lat/lon trackpoints, plus optional
+server-side reverse-geocoded start/end addresses.
+
+The address fields are nullable: in EU-region accounts the cloud almost
+never populates them, so consumers that need street strings should
+reverse-geocode client-side from ``start_position`` /
+``end_position`` (raw integer lat/lon in milliarcseconds; divide by
+3,600,000 for WGS84 decimal degrees).
+
+This module models a single most-recent trip plus a total trip counter,
+matching the surface area of the HelloSmart HA integration so consumers
+can build sensors on top of it without further parsing.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from pysmarthashtag.models import ValueWithUnit, get_field_as_type
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _parse_epoch_ms(value: Any) -> Optional[datetime]:
+    """Parse a millisecond epoch into a UTC-aware ``datetime``.
+
+    Tz-aware so HA's TIMESTAMP device class (used by sensor entities that
+    expose start/end times) accepts the value — naive datetimes show up
+    as ``unavailable``.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+@dataclass
+class TripJournal:
+    """The most-recent trip from the vehicle's journal log."""
+
+    trip_id: str = ""
+    """Cloud-assigned trip identifier."""
+
+    distance: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    """Trip distance."""
+
+    duration: Optional[int] = None
+    """Trip duration in seconds (as the cloud reports it)."""
+
+    energy_consumption: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    """Total energy consumed during the trip."""
+
+    avg_energy_consumption: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    """Average energy consumption (kWh / 100 km)."""
+
+    avg_speed: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    """Average trip speed."""
+
+    max_speed: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    """Maximum trip speed."""
+
+    start_time: Optional[datetime] = None
+    """Trip start time."""
+
+    end_time: Optional[datetime] = None
+    """Trip end time."""
+
+    regenerated_energy: Optional[ValueWithUnit] = ValueWithUnit(None, None)
+    """Energy recovered via regenerative braking."""
+
+    start_address: str = ""
+    """Server-side reverse-geocoded address at trip start.
+
+    Nullable: in EU-region accounts the cloud almost never populates this
+    field. Use ``start_position`` for the raw lat/lon and reverse-geocode
+    client-side if a string is needed.
+    """
+
+    end_address: str = ""
+    """Server-side reverse-geocoded address at trip end. Same caveat as
+    ``start_address`` — usually empty in EU.
+    """
+
+    start_position: Optional[tuple[int, int]] = None
+    """Trip-start coordinates as ``(latitude, longitude)`` in raw
+    milliarcseconds (divide each by 3,600,000 for WGS84 decimal degrees).
+    Derived from ``trackpoints[0].position`` in the cloud response.
+    Same scaling as :class:`pysmarthashtag.vehicle.position.Position`.
+    """
+
+    end_position: Optional[tuple[int, int]] = None
+    """Trip-end coordinates as ``(latitude, longitude)`` in raw
+    milliarcseconds. Derived from the last entry of ``trackpoints``.
+    """
+
+    total_trips: Optional[int] = None
+    """Total number of trips known to the cloud (top-level on the response)."""
+
+    @classmethod
+    def from_response(cls, response_data: dict) -> Optional["TripJournal"]:
+        """Build a TripJournal from a ``journalLogV4`` response body.
+
+        ``response_data`` is the full JSON dict returned by the endpoint,
+        i.e. the object containing ``code`` / ``message`` / ``data``.
+        The cloud returns ``data.list`` (most-recent first per
+        ``data.pagination.sortField/direction``) and
+        ``data.pagination.totleSize`` (sic — Geely's typo) for the total
+        trip count. Returns ``None`` if the response carries no usable
+        journal entry.
+        """
+        if not isinstance(response_data, dict):
+            return None
+        journal = response_data.get("data") or {}
+        logs = journal.get("list") or []
+        pagination = journal.get("pagination") or {}
+
+        total_trips = get_field_as_type(pagination, "totleSize", int)
+
+        if not logs:
+            if total_trips is not None:
+                # Vehicle has zero recorded trips but cloud responded — return
+                # an empty record so consumers can still see total_trips=0.
+                return cls(total_trips=total_trips)
+            return None
+
+        first = logs[0] or {}
+        # The cloud reverse-geocodes addresses asynchronously; the most
+        # recent trip often has ``tripStartAddr/tripEndAddr`` = null for
+        # minutes to hours after the trip ends. We deliberately surface
+        # the empty values rather than splicing addresses from a prior
+        # trip — the next refresh will pick them up once the cloud
+        # geocoder catches up.
+
+        distance = get_field_as_type(first, "traveledDistance", float)
+        # The cloud's ``electricConsumption`` field is the per-trip average
+        # in kWh/100km (a 2 km trip showing 25.0 corresponds to ~0.5 kWh
+        # consumed — consistent with kWh/100km, not kWh total).
+        avg_energy = get_field_as_type(first, "electricConsumption", float)
+        avg_speed = get_field_as_type(first, "avgSpeed", float)
+        regen = get_field_as_type(first, "regeneratedEnergy", float)
+
+        # Cloud doesn't include duration; compute from start/end timestamps.
+        start_ms = get_field_as_type(first, "startTime", int)
+        end_ms = get_field_as_type(first, "endTime", int)
+        duration_s: Optional[int] = None
+        if start_ms is not None and end_ms is not None and end_ms >= start_ms:
+            duration_s = (end_ms - start_ms) // 1000
+
+        # Compute total trip energy from avg consumption × distance / 100.
+        energy_total: Optional[float] = None
+        if avg_energy is not None and distance is not None:
+            energy_total = round(avg_energy * distance / 100, 3)
+
+        # Extract first/last trackpoint positions (raw int milliarcseconds).
+        trackpoints = first.get("trackpoints") or []
+        start_pos: Optional[tuple[int, int]] = None
+        end_pos: Optional[tuple[int, int]] = None
+        if trackpoints:
+            first_tp = (trackpoints[0] or {}).get("position") or {}
+            last_tp = (trackpoints[-1] or {}).get("position") or {}
+            tp_start_lat = get_field_as_type(first_tp, "latitude", int)
+            tp_start_lon = get_field_as_type(first_tp, "longitude", int)
+            tp_end_lat = get_field_as_type(last_tp, "latitude", int)
+            tp_end_lon = get_field_as_type(last_tp, "longitude", int)
+            if tp_start_lat is not None and tp_start_lon is not None:
+                start_pos = (tp_start_lat, tp_start_lon)
+            if tp_end_lat is not None and tp_end_lon is not None:
+                end_pos = (tp_end_lat, tp_end_lon)
+
+        return cls(
+            trip_id=str(first.get("tripId", "")),
+            distance=ValueWithUnit(distance, "km") if distance is not None else None,
+            duration=duration_s,
+            energy_consumption=(
+                ValueWithUnit(energy_total, "kWh") if energy_total is not None else None
+            ),
+            avg_energy_consumption=(
+                ValueWithUnit(avg_energy, "kWh/100km") if avg_energy is not None else None
+            ),
+            avg_speed=ValueWithUnit(avg_speed, "km/h") if avg_speed is not None else None,
+            max_speed=None,  # Not provided by the cloud; would require trackpoint analysis.
+            start_time=_parse_epoch_ms(start_ms),
+            end_time=_parse_epoch_ms(end_ms),
+            regenerated_energy=(
+                ValueWithUnit(regen, "kWh") if regen is not None else None
+            ),
+            start_address=str(first.get("tripStartAddr", "") or ""),
+            end_address=str(first.get("tripEndAddr", "") or ""),
+            start_position=start_pos,
+            end_position=end_pos,
+            total_trips=total_trips,
+        )

--- a/pysmarthashtag/vehicle/journal.py
+++ b/pysmarthashtag/vehicle/journal.py
@@ -119,7 +119,11 @@ class TripJournal:
         if not isinstance(response_data, dict):
             return None
         journal = response_data.get("data") or {}
-        logs = journal.get("list") or []
+        # Defensive: cloud-side schema drift could return a non-list type, in
+        # which case a bare `or []` keeps the truthy non-list and indexing
+        # below would raise. isinstance check coerces to [] for any non-list.
+        logs_raw = journal.get("list")
+        logs = logs_raw if isinstance(logs_raw, list) else []
         pagination = journal.get("pagination") or {}
 
         total_trips = get_field_as_type(pagination, "totleSize", int)
@@ -160,7 +164,9 @@ class TripJournal:
             energy_total = round(avg_energy * distance / 100, 3)
 
         # Extract first/last trackpoint positions (raw int milliarcseconds).
-        trackpoints = first.get("trackpoints") or []
+        # Same isinstance guard as above — defensive against schema drift.
+        trackpoints_raw = first.get("trackpoints")
+        trackpoints = trackpoints_raw if isinstance(trackpoints_raw, list) else []
         start_pos: Optional[tuple[int, int]] = None
         end_pos: Optional[tuple[int, int]] = None
         if trackpoints:

--- a/pysmarthashtag/vehicle/vehicle.py
+++ b/pysmarthashtag/vehicle/vehicle.py
@@ -8,6 +8,7 @@ from pysmarthashtag.const import API_BASE_URL, API_BASE_URL_V2
 from pysmarthashtag.models import ValueWithUnit, get_element_from_dict_maybe
 from pysmarthashtag.vehicle.battery import Battery
 from pysmarthashtag.vehicle.climate import Climate
+from pysmarthashtag.vehicle.journal import TripJournal
 from pysmarthashtag.vehicle.maintenance import Maintenance
 from pysmarthashtag.vehicle.position import Position
 from pysmarthashtag.vehicle.running import Running
@@ -56,6 +57,9 @@ class SmartVehicle:
     safety: Optional[Safety] = None
     """The safety status of the vehicle."""
 
+    last_trip: Optional[TripJournal] = None
+    """The most recent trip from the journal log (server-side reverse-geocoded)."""
+
     climate_control: Optional["ClimateControll"] = None  # noqa: F821
 
     charging_control: Optional["ChargingControl"] = None  # noqa: F821
@@ -102,6 +106,7 @@ class SmartVehicle:
         charging_settings: Optional[dict] = None,
         ota_info: Optional[dict] = None,
         fetched_at: Optional[datetime.datetime] = None,
+        journal_response: Optional[dict] = None,
     ) -> dict:
         """Combine all data into one dictionary."""
         self.data.update(vehicle_base)
@@ -121,6 +126,11 @@ class SmartVehicle:
         self.running = Running.from_vehicle_data(self.data)
         self.climate = Climate.from_vehicle_data(self.data)
         self.safety = Safety.from_vehicle_data(self.data)
+        if journal_response is not None:
+            # Only overwrite when the caller actually has fresh journal data.
+            # Other endpoints (e.g. status, SOC, OTA) call combine_data without
+            # this kwarg and must not blow away an already-populated trip.
+            self.last_trip = TripJournal.from_response(journal_response)
 
         from pysmarthashtag.control.climate import ClimateControll
 

--- a/pysmarthashtag/vehicle/vehicle.py
+++ b/pysmarthashtag/vehicle/vehicle.py
@@ -65,6 +65,9 @@ class SmartVehicle:
     charging_control: Optional["ChargingControl"] = None  # noqa: F821
     """Control for starting/stopping charging."""
 
+    journal_recording_control: Optional["JournalRecordingControl"] = None  # noqa: F821
+    """Control for enabling/disabling on-vehicle trip recording."""
+
     engine_state: Optional[str] = None
     """The state of the engine."""
 
@@ -139,6 +142,10 @@ class SmartVehicle:
         from pysmarthashtag.control.charging import ChargingControl
 
         self.charging_control = ChargingControl(self.account, self.vin)
+
+        from pysmarthashtag.control.journal import JournalRecordingControl
+
+        self.journal_recording_control = JournalRecordingControl(self.account, self.vin)
 
     def _parse_data(self) -> None:
         self.vin = self.data.get("vin")


### PR DESCRIPTION
Adds support for the per-vehicle trip log endpoint
`/geelyTCAccess/tcservices/vehicle/status/journalLogV4/{vin}` plus the
on-vehicle recording toggle. Together they give consumers a complete
trip-log surface: enable recording → wait for trips → read them.

## What's new

### `SmartAccount.get_trip_journal(vin, page_size, window_days)`
Fetches the most recent trips for a vehicle. Returns the raw response
dict; `vehicle.last_trip` is set automatically on every `get_vehicles()`
refresh via the new `journal_response=` kwarg on `combine_data()`.

### `SmartAccount.grant_journal_authorization(vin, force=False)`
The journalLogV4 endpoint is gated by a per-session authorization
handshake at `/remote-control/user/authorization/insert` with
`{"serviceCode": "travelLogBusiCode", "authStatus": 1, "vin": <vin>}`.
Without it the endpoint returns `code: 8153` even when the on-vehicle
recording flag is set and trip data exists cloud-side. `get_trip_journal`
calls this transparently before each fetch.

The grant POST has a quirk: it **rotates the access_token server-side**.
Without caching, every `get_trip_journal()` call would force the next
call to refresh the token and retry — burning ~2x API calls per poll.
SmartHashtag's coordinator polls every 5 min idle / 60 s driving / 30 s
charging, so without the cache that's up to ~120 wasted call-pairs/hour
during charging. To avoid that, this PR adds a per-VIN, per-access-token
grant cache on `SmartAccount` (`_journal_grant_cache: dict[str, str]`):

* First call → POSTs the grant, stores `{vin: access_token}` mapping
* Subsequent calls under the same token → short-circuit, return `True`
  without POSTing
* Token rotation (any cause: this grant, unrelated refresh, manual
  relogin) → cache lookup misses, grant is re-POSTed, new token stored
* `force=True` parameter for explicit re-grant flows (init, debugging)

### `pysmarthashtag.vehicle.journal.TripJournal`
Dataclass for a single trip with: `trip_id`, `distance` (km),
`duration` (s — computed from start/end timestamps; the cloud doesn't
include duration directly), `energy_consumption` (kWh, computed),
`avg_energy_consumption` (kWh/100km — what `electricConsumption`
actually is per observation), `avg_speed`, tz-aware UTC `start_time` /
`end_time` (so HA's TIMESTAMP device class accepts them),
`regenerated_energy`, `start_address` / `end_address` (cloud-side
reverse-geocoded; nullable — see caveat below), `start_position` /
`end_position` (raw int milliarcseconds from the trackpoints array,
matching the `Position` model's scaling), `total_trips`
(`pagination.totleSize`, sic — Geely's typo).

### `pysmarthashtag.control.journal.JournalRecordingControl`
Helper for toggling the on-vehicle recording flag at
`/remote-control/vehicle/status/journalLog/{vin}` (PUT, JOU envelope:
`serviceId: "JOU"`, `serviceParameters: [{"key": "jou", "value":
"enable"|"disable"}]`, `command: "start"|"stop"`,
`operationScheduling: {recurrentOperation: true, duration: 60, ...}`).
Mirrored on each vehicle as `vehicle.journal_recording_control`.

## Caveats

* `tripStartAddr` / `tripEndAddr` are reverse-geocoded server-side, but
  EU-region accounts almost never get them populated (verified across
  50 trips spanning 90 days — none had populated addresses on this
  account). Consumers that need street strings should reverse-geocode
  client-side from `start_position` / `end_position`.
* The journalLogV4 endpoint returns `code: 8153` ("data unavailable")
  on vehicles where the on-vehicle recording flag is OFF. The companion
  `JournalRecordingControl.enable_recording()` flips that flag.
* `electricConsumption` is the trip-average in kWh/100km, not absolute
  kWh — verified empirically (a 2 km trip showing 25.0 corresponds to
  ~0.5 kWh actual consumption). The dataclass exposes both: the raw
  average via `avg_energy_consumption` and a computed total via
  `energy_consumption`.

## Tests

110 tests pass; pre-commit clean. Mock router covers both the
auth-grant POST and the journal GET; an end-to-end test verifies
`vehicle.last_trip` is populated by `get_vehicles()`; a separate test
verifies an 8153 response doesn't break the rest of the refresh; and
`test_grant_authorization_caches_per_vin_token` exercises the four cache
behaviors (first-call POSTs, second-call short-circuits, `force=True`
bypasses, manual token rotation auto-invalidates).

## Reference

* Endpoint shape and required preconditions match what the `HelloSmart`
  HA integration ([onpremcloudguy](https://github.com/onpremcloudguy/HelloSmart_HomeAssistant))
  documents for journalLogV4, plus the auth-grant handshake (which that
  integration doesn't yet implement — it relies on the user toggling
  recording from the official app).
* Companion SmartHashtag PR adds sensor entities for the new
  TripJournal fields (will follow this one once a release lands on PyPI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View per-vehicle trip history (distance, duration, energy, regenerated energy, addresses, GPS trackpoints).
  * Toggle on-vehicle trip recording (enable/disable).
  * Vehicle refresh now fetches trip data automatically and populates each vehicle’s latest trip.

* **Bug Fixes / Improvements**
  * Graceful handling when journal requests fail so refresh still completes.
  * Reduced redundant authorization calls for journal access; supports forced reauthorization.

* **Tests**
  * Comprehensive tests covering journal parsing, controls, caching, and resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->