### PR TITLE
fix: redact secret tokens from URLs before logging

### DIFF
--- a/pysmarthashtag/api/authentication.py
+++ b/pysmarthashtag/api/authentication.py
@@ -17,7 +17,7 @@ import httpx
 from httpx._models import Request, Response
 
 from pysmarthashtag.api import utils
-from pysmarthashtag.api.log_sanitizer import sanitize_log_data
+from pysmarthashtag.api.log_sanitizer import sanitize_log_data, sanitize_url
 from pysmarthashtag.const import (
     API_SESION_URL,
     HTTPX_TIMEOUT,
@@ -123,7 +123,7 @@ class SmartAuthentication(httpx.Auth):
 
     async def async_auth_flow(self, request: Request) -> AsyncGenerator[Request, Response]:
         """Asynchronous authentication flow for handling requests and retrying on rate limit errors."""
-        _LOGGER.debug("Handling request %s", request.url)
+        _LOGGER.debug("Handling request %s", sanitize_url(request.url))
         # Get an initial login on first call
         async with self.login_lock:
             if not self.access_token:
@@ -165,8 +165,8 @@ class SmartAuthentication(httpx.Auth):
         except httpx.HTTPStatusError as exc:
             _LOGGER.error(
                 "Error handling request %s: %s",
-                request.url,
-                exc,
+                sanitize_url(request.url),
+                sanitize_log_data(str(exc)),
             )
             raise
 
@@ -602,20 +602,20 @@ class SmartLoginClient(httpx.AsyncClient):
                 except httpx.HTTPStatusError as exc:
                     _LOGGER.error(
                         "Error handling request %s: %s",
-                        response.url,
-                        exc,
+                        sanitize_url(response.url),
+                        sanitize_log_data(str(exc)),
                     )
                     raise
 
         kwargs["event_hooks"]["response"].append(raise_for_status_handler)
 
         async def log_request(request):
-            _LOGGER.debug("Request: %s %s", request.method, request.url)
+            _LOGGER.debug("Request: %s %s", request.method, sanitize_url(request.url))
 
         async def log_response(response):
             await response.aread()
             request = response.request
-            _LOGGER.debug("Response: %s %s - Status %d", request.method, request.url, response.status_code)
+            _LOGGER.debug("Response: %s %s - Status %d", request.method, sanitize_url(request.url), response.status_code)
 
         kwargs["event_hooks"]["response"].append(log_response)
         kwargs["event_hooks"]["request"].append(log_request)
@@ -649,8 +649,8 @@ class SmartLoginRetry(httpx.Auth):
                     except httpx.HTTPStatusError as exc:
                         _LOGGER.error(
                             "Error handling request %s: %s",
-                            request.url,
-                            exc,
+                            sanitize_url(request.url),
+                            sanitize_log_data(str(exc)),
                         )
                         raise
 

--- a/pysmarthashtag/api/client.py
+++ b/pysmarthashtag/api/client.py
@@ -7,6 +7,7 @@ from typing import Optional
 import httpx
 
 from pysmarthashtag.api.authentication import SmartAuthentication
+from pysmarthashtag.api.log_sanitizer import sanitize_url
 from pysmarthashtag.api.ssl_context import get_ssl_context_async
 from pysmarthashtag.const import (
     HTTPX_TIMEOUT,
@@ -83,12 +84,12 @@ class SmartClient(httpx.AsyncClient):
         kwargs["event_hooks"] = defaultdict(list, **kwargs.get("event_hooks", {}))
 
         async def log_request(request):
-            _LOGGER.debug("Request: %s %s", request.method, request.url)
+            _LOGGER.debug("Request: %s %s", request.method, sanitize_url(request.url))
 
         async def log_response(response):
             await response.aread()
             request = response.request
-            _LOGGER.debug("Response: %s %s - Status %d", request.method, request.url, response.status_code)
+            _LOGGER.debug("Response: %s %s - Status %d", request.method, sanitize_url(request.url), response.status_code)
 
         kwargs["event_hooks"]["response"].append(log_response)
         kwargs["event_hooks"]["request"].append(log_request)

--- a/pysmarthashtag/api/log_sanitizer.py
+++ b/pysmarthashtag/api/log_sanitizer.py
@@ -2,6 +2,7 @@
 
 import re
 from typing import Any, Union
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 # Fields that should be masked in log output
 SENSITIVE_FIELDS = frozenset(
@@ -39,9 +40,29 @@ SENSITIVE_FIELDS = frozenset(
     }
 )
 
+# URL query/fragment parameter names that carry secrets
+SENSITIVE_URL_PARAMS = frozenset(
+    {
+        "access_token",
+        "refresh_token",
+        "login_token",
+        "token",
+        "code",
+        "context",
+    }
+)
+
 # Regex patterns for VIN and tokens in text
 VIN_PATTERN = re.compile(r"\b[A-HJ-NPR-Z0-9]{17}\b")
 TOKEN_PATTERN = re.compile(r"(Bearer\s+)[A-Za-z0-9_\-]+\.?[A-Za-z0-9_\-]*\.?[A-Za-z0-9_\-]*")
+# Matches sensitive key=value pairs in query strings embedded in text (e.g. login_token=abc123&)
+_URL_PARAM_PATTERN = re.compile(
+    r"(?<=[?&])((?:access_token|refresh_token|login_token|token|code|context)"
+    r")=([^&#\s]+)",
+    re.IGNORECASE,
+)
+# Matches glt_<apikey>=<login_token> cookie/query values
+_GLT_PATTERN = re.compile(r"(glt_[A-Za-z0-9_]+)=([^;&\s]+)")
 
 # Pre-computed normalized sensitive field names for efficient lookup
 _NORMALIZED_SENSITIVE_FIELDS = frozenset(f.replace("_", "") for f in SENSITIVE_FIELDS)
@@ -126,8 +147,47 @@ def _sanitize_list(data: list, depth: int = 0, max_depth: int = 10) -> list:
     return result
 
 
+def sanitize_url(url: Any) -> str:
+    """Redact sensitive query and fragment parameters from a URL.
+
+    Handles httpx.URL objects and plain strings.
+    """
+    url_str = str(url)
+    try:
+        parsed = urlparse(url_str)
+    except Exception:
+        return "***"
+
+    redacted_query = _redact_params(parsed.query)
+    redacted_fragment = _redact_params(parsed.fragment)
+
+    return urlunparse((
+        parsed.scheme,
+        parsed.netloc,
+        parsed.path,
+        parsed.params,
+        redacted_query,
+        redacted_fragment,
+    ))
+
+
+def _redact_params(raw: str) -> str:
+    """Redact sensitive key=value pairs in a query/fragment string."""
+    if not raw:
+        return raw
+    params = parse_qs(raw, keep_blank_values=True)
+    changed = False
+    for key in list(params):
+        if key.lower() in SENSITIVE_URL_PARAMS or key.lower().startswith("glt_"):
+            params[key] = ["***"]
+            changed = True
+    if not changed:
+        return raw
+    return urlencode(params, doseq=True)
+
+
 def _sanitize_string(data: str) -> str:
-    """Sanitize a string by masking VINs and tokens.
+    """Sanitize a string by masking VINs, tokens, and sensitive URL params.
 
     Args:
     ----
@@ -142,6 +202,10 @@ def _sanitize_string(data: str) -> str:
     result = VIN_PATTERN.sub(lambda m: _mask_value(m.group()), data)
     # Mask Bearer tokens
     result = TOKEN_PATTERN.sub(r"\1***", result)
+    # Mask sensitive query parameters embedded in text
+    result = _URL_PARAM_PATTERN.sub(r"\1=***", result)
+    # Mask glt_<apikey>=<token> patterns
+    result = _GLT_PATTERN.sub(r"\1=***", result)
     return result
 
 


### PR DESCRIPTION
Login/OAuth tokens (login_token, access_token, refresh_token) appear in URL query strings and fragments during the auth flow. The httpx event hooks (log_request, log_response, raise_for_status_handler) logged these URLs verbatim at DEBUG and ERROR levels, leaking live credentials to log files.

Add sanitize_url() to log_sanitizer.py that strips sensitive query and fragment parameters. Apply it to all URL logging in authentication.py (SmartLoginClient, SmartLoginRetry, SmartAuthentication.async_auth_flow) and client.py (SmartClient). Also extend _sanitize_string to catch param=value and glt_<key>=<token> patterns in arbitrary text.

https://claude.ai/code/session_01TFLXNPgy1T5kvNaBB6VUx7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced log sanitization to prevent exposure of sensitive information (API credentials, tokens, and query parameters) in application logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->