### PR TITLE
feat(journal): page-loop pageIndex=2..N until totleSize / short page

### DIFF
--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -1,22 +1,80 @@
 """Access to Smart account for your vehicles therin."""
 
+import asyncio
 import datetime
 import json
 import logging
 from dataclasses import InitVar, dataclass, field
 from typing import Optional
 
+import httpx
+
 from pysmarthashtag.api import utils
 from pysmarthashtag.api.authentication import SmartAuthentication
 from pysmarthashtag.api.client import SmartClient, SmartClientConfiguration
 from pysmarthashtag.api.log_sanitizer import sanitize_log_data
 from pysmarthashtag.const import API_CARS_URL, API_SELECT_CAR_URL, EndpointUrls
-from pysmarthashtag.models import SmartAuthError, SmartHumanCarConnectionError, SmartTokenRefreshNecessary
+from pysmarthashtag.models import (
+    JournalTruncationError,
+    SmartAuthError,
+    SmartHumanCarConnectionError,
+    SmartTokenRefreshNecessary,
+)
 from pysmarthashtag.vehicle.vehicle import SmartVehicle
 
 VALID_UNTIL_OFFSET = datetime.timedelta(seconds=10)
 
+# Cloud's "data unavailable" code on the journal endpoints. The SDK's
+# raise_for_status hook surfaces it as :class:`httpx.HTTPStatusError`;
+# the page-loop normalises it to "end of data" so a transient cloud
+# blip mid-loop doesn't fail the whole poll.
+_BENIGN_EMPTY_CODE = "8153"
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def _is_benign_empty(exc: httpx.HTTPStatusError) -> bool:
+    """Return True iff ``exc`` carries the cloud's 8153 "data unavailable" code."""
+    response = exc.response
+    if response is None:
+        return False
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+    return str(body.get("code")) == _BENIGN_EMPTY_CODE
+
+
+def _unwrap_journal_page(body: dict) -> tuple[list, Optional[int]]:
+    """Pull ``data.list`` and ``data.pagination.totleSize`` out of a journal body.
+
+    Returns ``([], None)`` for missing/None ``data`` (the cloud
+    occasionally returns a top-level ``code: 1000`` with ``data: null``
+    on empty windows, which we treat as a benign empty page).
+
+    The cloud's response envelope uses the typo "totleSize" (sic) for
+    the total-records field — preserve the misspelling so the existing
+    parser keeps working.
+    """
+    if not isinstance(body, dict):
+        return [], None
+    data = body.get("data")
+    if not isinstance(data, dict):
+        return [], None
+    items_raw = data.get("list")
+    items = items_raw if isinstance(items_raw, list) else []
+    pagination = data.get("pagination")
+    total_raw = pagination.get("totleSize") if isinstance(pagination, dict) else None
+    if isinstance(total_raw, bool):
+        # bool is an int subclass — guard so True/False never become 1/0.
+        total = None
+    elif isinstance(total_raw, (int, float)):
+        total = int(total_raw)
+    elif isinstance(total_raw, str) and total_raw.strip().isdigit():
+        total = int(total_raw.strip())
+    else:
+        total = None
+    return list(items), total
 
 
 @dataclass
@@ -360,8 +418,15 @@ class SmartAccount:
                 break
         return False
 
-    async def get_trip_journal(self, vin, page_size: int = 20, window_days: int = 14) -> dict:
-        """Fetch the most recent trip-journal entries for a vehicle.
+    async def get_trip_journal(
+        self,
+        vin,
+        page_size: int = 20,
+        window_days: int = 14,
+        raise_on_truncation: bool = False,
+        page_gap_seconds: float = 0.0,
+    ) -> dict:
+        """Fetch trip-journal entries for a vehicle, page-looping ``pageIndex=1..N``.
 
         Hits ``/geelyTCAccess/tcservices/vehicle/status/journalLogV4/{vin}``
         — the endpoint that carries server-side reverse-geocoded start/end
@@ -375,17 +440,142 @@ class SmartAccount:
         is cached per-VIN per-access-token, so subsequent calls under the
         same token skip the grant POST.
 
-        Returns the raw response dict (with ``code``/``message``/``data``)
-        or an empty dict when the request fails server-side; raising is
-        avoided so a single flaky vehicle doesn't break the whole refresh.
+        Page-loops ``pageIndex=2, 3, ...`` until **either** the
+        cloud-reported ``totleSize`` is reached **or** the previous page
+        came back short (the cloud's "no more pages" signal — fewer rows
+        than the requested ``page_size``). Accounts with more trips in
+        the window than ``page_size`` no longer silently lose the tail.
+
+        A ``code=8153`` mid-loop is treated as end-of-data and breaks
+        the loop with whatever's accumulated; the first page's 8153
+        still propagates as :class:`httpx.HTTPStatusError` so callers
+        with their own benign-empty handling (e.g. :meth:`get_vehicles`)
+        keep working unchanged.
+
+        After the loop, if the accumulated count disagrees with the
+        cloud's ``totleSize``:
+
+        * with ``raise_on_truncation=False`` (default), logs a WARNING
+          with both numbers and returns the partial accumulated dict —
+          routine polls keep going so the next iteration can pick up
+          the missing trips.
+        * with ``raise_on_truncation=True``, raises
+          :class:`pysmarthashtag.models.JournalTruncationError` instead.
+          Used by backfill/archive callers where silent data loss is
+          worse than a hard failure that forces an operator to look.
+
+        ``page_gap_seconds`` lets callers insert a polite-API sleep
+        between successive page fetches (default 0.0 — the SDK has no
+        opinion; consumers that want one set their own).
+
+        Returns a dict with the same shape as the cloud's first-page
+        response (``code`` / ``message`` / ``data``) but with
+        ``data.list`` containing the merged entries from every page.
+        ``data.pagination.totleSize`` carries the cloud's most recent
+        report. Returns an empty dict only when the page-1 request
+        itself fails server-side (preserved from the prior single-page
+        behaviour so a single flaky vehicle doesn't break the refresh).
         """
         await self.grant_journal_authorization(vin)
         _LOGGER.debug("Getting trip journal for vehicle")
         end_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
         start_ms = end_ms - window_days * 86400 * 1000
+
+        first = await self._fetch_journal_page(vin, 1, page_size, start_ms, end_ms)
+        if not first:
+            return {}
+
+        accumulated, total = _unwrap_journal_page(first)
+        if not accumulated:
+            return first
+        last_page_count = len(accumulated)
+
+        page_index = 2
+        while True:
+            # Stop conditions before issuing another request:
+            # - cloud-reported total has been reached/exceeded, OR
+            # - the previous page came back short (cloud's "no more
+            #   pages" signal — fewer rows than requested).
+            if total is not None and len(accumulated) >= total:
+                break
+            if last_page_count < page_size:
+                break
+
+            if page_gap_seconds > 0:
+                await asyncio.sleep(page_gap_seconds)
+
+            try:
+                page = await self._fetch_journal_page(
+                    vin, page_index, page_size, start_ms, end_ms
+                )
+            except httpx.HTTPStatusError as exc:
+                if _is_benign_empty(exc):
+                    _LOGGER.debug(
+                        "journalLogV4 returned 8153 mid-loop for %s at page %d; treating as end-of-data",
+                        sanitize_log_data(vin),
+                        page_index,
+                    )
+                    break
+                raise
+
+            page_items, page_total = _unwrap_journal_page(page)
+            if page_total is not None:
+                total = page_total
+            if not page_items:
+                break
+            accumulated.extend(page_items)
+            last_page_count = len(page_items)
+            page_index += 1
+
+        if total is not None and total != len(accumulated):
+            if raise_on_truncation:
+                raise JournalTruncationError(
+                    f"page-loop for {sanitize_log_data(vin)} accumulated "
+                    f"{len(accumulated)} items but cloud reported "
+                    f"totleSize={total}; aborting rather than silently "
+                    "returning an incomplete history"
+                )
+            _LOGGER.warning(
+                "Journal page-loop truncation for %s: accumulated %d items "
+                "but cloud reported totleSize=%d. Possible silent data loss — "
+                "investigate page-loop termination.",
+                sanitize_log_data(vin),
+                len(accumulated),
+                total,
+            )
+
+        # Rebuild the response shape with the merged list and the
+        # final totleSize so consumers parsing ``data.list`` see all
+        # pages without needing to know there was a loop.
+        merged = dict(first)
+        merged_data = dict(merged.get("data") or {})
+        merged_data["list"] = accumulated
+        if total is not None:
+            merged_pagination = dict(merged_data.get("pagination") or {})
+            merged_pagination["totleSize"] = total
+            merged_data["pagination"] = merged_pagination
+        merged["data"] = merged_data
+        return merged
+
+    async def _fetch_journal_page(
+        self,
+        vin: str,
+        page_index: int,
+        page_size: int,
+        start_ms: int,
+        end_ms: int,
+    ) -> dict:
+        """Fetch a single page of journalLogV4 for ``vin``.
+
+        Mirrors the request construction the previous single-page
+        :meth:`get_trip_journal` did, parameterised by ``page_index``.
+        The auth-grant POST is NOT issued here — the caller does it
+        once before the loop, since the cache short-circuits subsequent
+        fetches under the same token anyway.
+        """
         params = {
             "endTime": str(end_ms),
-            "pageIndex": "1",
+            "pageIndex": str(page_index),
             "pageSize": str(page_size),
             "startTime": str(start_ms),
             "userId": str(self.config.authentication.api_user_id),
@@ -396,7 +586,7 @@ class SmartAccount:
         async with SmartClient(self.config) as client:
             for retry in range(3):
                 try:
-                    r_journal = await client.get(
+                    response = await client.get(
                         self.vehicles[vin].base_url + url,
                         headers={
                             **utils.generate_default_header(
@@ -408,8 +598,8 @@ class SmartAccount:
                             )
                         },
                     )
-                    _LOGGER.debug("Got response %d", r_journal.status_code)
-                    data = r_journal.json()
+                    _LOGGER.debug("Got response %d", response.status_code)
+                    data = response.json()
                 except SmartTokenRefreshNecessary:
                     _LOGGER.debug("Got Token Error, retry: %d", retry)
                     continue

--- a/pysmarthashtag/models.py
+++ b/pysmarthashtag/models.py
@@ -96,6 +96,19 @@ class SmartRemoteServiceError(SmartAPIError):
     """Error when executing web services."""
 
 
+class JournalTruncationError(SmartAPIError):
+    """Page-loop accumulated count disagreed with the cloud-reported total.
+
+    Raised by :meth:`pysmarthashtag.account.SmartAccount.get_trip_journal`
+    when ``raise_on_truncation=True`` and the merged page-loop ended with
+    ``len(data.list) != totleSize``. The default of ``raise_on_truncation
+    =False`` instead logs a WARNING — routine polls keep going so the
+    next iteration can pick up the missing trips. Backfill / archive
+    callers can opt into the hard failure: a backfill that silently lost
+    data is worse than one that aborts and forces investigation.
+    """
+
+
 def get_element_from_dict_maybe(
     data: dict, *path: str, default: "Any|None" = None
 ) -> Optional[Union[dict, str, int, float]]:

--- a/pysmarthashtag/tests/test_journal_pagination.py
+++ b/pysmarthashtag/tests/test_journal_pagination.py
@@ -1,0 +1,289 @@
+"""Tests for journalLogV4 ``pageIndex`` looping inside :meth:`SmartAccount.get_trip_journal`."""
+
+import logging
+import re
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+import respx
+
+from pysmarthashtag.const import API_BASE_URL, API_BASE_URL_V2
+from pysmarthashtag.models import JournalTruncationError
+from pysmarthashtag.tests.conftest import prepare_account_with_vehicles
+
+_JOURNAL_PATH = "/geelyTCAccess/tcservices/vehicle/status/journalLogV4/"
+
+
+def _trip(trip_id: int, start_ms: int = 1_700_000_000_000, end_ms: int = 1_700_000_600_000) -> dict:
+    """Build a minimal journalLogV4 trip record."""
+    return {
+        "tripId": trip_id,
+        "startTime": start_ms,
+        "endTime": end_ms,
+        "traveledDistance": 1.0,
+    }
+
+
+def _page_body(items: list, total: int, page_index: int = 1, page_size: int = 20) -> dict:
+    """Build a journalLogV4 page response body."""
+    return {
+        "code": "1000",
+        "message": "operation succeed",
+        "success": True,
+        "data": {
+            "pagination": {
+                "pageIndex": page_index,
+                "sortField": "startTime",
+                "start": 1,
+                "pageSize": page_size,
+                "totleSize": total,
+                "direction": "desc",
+            },
+            "list": items,
+        },
+    }
+
+
+def _install_paginated_routes(
+    smart_fixture: respx.Router,
+    pages_by_index: dict[int, dict],
+    *,
+    vin: str = "TestVIN0000000001",
+) -> list[httpx.Request]:
+    """Install a journalLogV4 mock that dispatches by ``pageIndex`` query param.
+
+    Returns a list that gets a request appended on every call, so tests
+    can introspect call ordering. ``pages_by_index`` maps ``pageIndex``
+    int → response body. A request whose ``pageIndex`` is missing from
+    the dict yields an empty page (defensive — exposes test bugs).
+    """
+    captured: list[httpx.Request] = []
+
+    def _dispatch(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        qs = parse_qs(urlparse(str(request.url)).query)
+        page_index = int((qs.get("pageIndex") or ["0"])[0])
+        body = pages_by_index.get(page_index, _page_body([], 0, page_index=page_index))
+        return httpx.Response(200, json=body)
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        smart_fixture.get(re.compile(re.escape(base + _JOURNAL_PATH + vin) + r".*")).mock(
+            side_effect=_dispatch
+        )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_loops_until_totleSize_reached(smart_fixture: respx.Router):
+    """Loop pages 2..N until accumulated count meets ``totleSize``.
+
+    The cloud reports more trips than ``page_size`` here; the merged
+    response must contain entries from every page in cloud order.
+    """
+    page1 = _page_body([_trip(i) for i in range(2, 0, -1)], total=4, page_size=2)
+    page2 = _page_body([_trip(i) for i in range(4, 2, -1)], total=4, page_index=2, page_size=2)
+    captured = _install_paginated_routes(smart_fixture, {1: page1, 2: page2})
+
+    account = await prepare_account_with_vehicles()
+    merged = await account.get_trip_journal("TestVIN0000000001", page_size=2)
+
+    # Both pages were fetched.
+    page_indices = [
+        int(parse_qs(urlparse(str(r.url)).query)["pageIndex"][0])
+        for r in captured
+        if "TestVIN0000000001" in str(r.url)
+    ]
+    # `prepare_account_with_vehicles` calls get_vehicles, which itself
+    # invokes get_trip_journal → page-loop. So the captured list may
+    # contain BOTH that initial loop AND ours. Just assert that pages
+    # 1 and 2 each appear at least once.
+    assert 1 in page_indices
+    assert 2 in page_indices
+
+    # Merged data.list contains all 4 trips, in the order they were
+    # received (newest-first per cloud direction=desc, preserved
+    # across pages).
+    assert len(merged["data"]["list"]) == 4
+    trip_ids = [trip["tripId"] for trip in merged["data"]["list"]]
+    assert trip_ids == [2, 1, 4, 3]
+    assert merged["data"]["pagination"]["totleSize"] == 4
+
+
+@pytest.mark.asyncio
+async def test_short_page_stops_loop(smart_fixture: respx.Router):
+    """A short page is the cloud's "no more pages" signal.
+
+    Stop looping when the cloud delivers fewer items than ``page_size``,
+    even if ``totleSize`` claims more — the cloud doesn't error on
+    over-paginating, it just short-pages.
+    """
+    # totleSize claims 100 but the cloud actually short-pages at 1 entry.
+    page1 = _page_body([_trip(1)], total=100, page_size=2)
+    captured = _install_paginated_routes(smart_fixture, {1: page1})
+
+    account = await prepare_account_with_vehicles()
+    merged = await account.get_trip_journal("TestVIN0000000001", page_size=2)
+
+    # Only page 1 was fetched for this loop (short-page → no page 2).
+    # The route DID see page 1 fetched twice though — once during
+    # get_vehicles' own get_trip_journal call, and once for ours.
+    our_call_indices = [
+        int(parse_qs(urlparse(str(r.url)).query)["pageIndex"][0])
+        for r in captured
+    ]
+    assert 2 not in our_call_indices, "short page must short-circuit page 2"
+
+    assert len(merged["data"]["list"]) == 1
+    assert merged["data"]["list"][0]["tripId"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mid_loop_8153_breaks_loop(smart_fixture: respx.Router):
+    """Mid-loop 8153 is benign end-of-data, not an error.
+
+    Page 2's ``code: 8153`` ("data unavailable") breaks the loop and
+    returns what's accumulated; the caller does not see an exception.
+    """
+    page1 = _page_body([_trip(1), _trip(2)], total=10, page_size=2)
+
+    def _dispatch(request: httpx.Request) -> httpx.Response:
+        qs = parse_qs(urlparse(str(request.url)).query)
+        page_index = int((qs.get("pageIndex") or ["0"])[0])
+        if page_index == 1:
+            return httpx.Response(200, json=page1)
+        return httpx.Response(200, json={"code": "8153", "message": "Connection interruption"})
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        smart_fixture.get(
+            re.compile(re.escape(base + _JOURNAL_PATH + "TestVIN0000000001") + r".*")
+        ).mock(side_effect=_dispatch)
+
+    account = await prepare_account_with_vehicles()
+    # No raise — 8153 mid-loop is benign end-of-data.
+    merged = await account.get_trip_journal("TestVIN0000000001", page_size=2)
+
+    # Accumulated only page 1's 2 entries; page 2 was 8153.
+    assert len(merged["data"]["list"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_mid_loop_other_error_propagates(smart_fixture: respx.Router):
+    """A non-8153 cloud error mid-loop propagates as ``HTTPStatusError``."""
+    page1 = _page_body([_trip(1), _trip(2)], total=10, page_size=2)
+
+    def _dispatch(request: httpx.Request) -> httpx.Response:
+        qs = parse_qs(urlparse(str(request.url)).query)
+        page_index = int((qs.get("pageIndex") or ["0"])[0])
+        if page_index == 1:
+            return httpx.Response(200, json=page1)
+        return httpx.Response(200, json={"code": "5000", "message": "Internal server error"})
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        smart_fixture.get(
+            re.compile(re.escape(base + _JOURNAL_PATH + "TestVIN0000000001") + r".*")
+        ).mock(side_effect=_dispatch)
+
+    account = await prepare_account_with_vehicles()
+    with pytest.raises(httpx.HTTPStatusError):
+        await account.get_trip_journal("TestVIN0000000001", page_size=2)
+
+
+@pytest.mark.asyncio
+async def test_truncation_warn_when_count_disagrees(
+    smart_fixture: respx.Router, caplog: pytest.LogCaptureFixture
+):
+    """Truncation logs a WARNING by default; loop returns the partial result.
+
+    Routine polls keep going so the next iteration can pick up the
+    missing trips, instead of failing the whole refresh on a mismatch.
+    """
+    # Cloud reports totleSize=10 but only delivers 1 short page → mismatch.
+    page1 = _page_body([_trip(1)], total=10, page_size=2)
+    _install_paginated_routes(smart_fixture, {1: page1})
+
+    account = await prepare_account_with_vehicles()
+    with caplog.at_level(logging.WARNING, logger="pysmarthashtag.account"):
+        merged = await account.get_trip_journal("TestVIN0000000001", page_size=2)
+
+    assert len(merged["data"]["list"]) == 1
+    assert merged["data"]["pagination"]["totleSize"] == 10
+    assert any(
+        "page-loop truncation" in record.message
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    )
+
+
+@pytest.mark.asyncio
+async def test_truncation_raises_when_caller_opts_in(smart_fixture: respx.Router):
+    """``raise_on_truncation=True`` upgrades the WARNING to a hard failure."""
+    page1 = _page_body([_trip(1)], total=10, page_size=2)
+    _install_paginated_routes(smart_fixture, {1: page1})
+
+    account = await prepare_account_with_vehicles()
+    with pytest.raises(JournalTruncationError):
+        await account.get_trip_journal(
+            "TestVIN0000000001", page_size=2, raise_on_truncation=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_loop_when_first_page_short(smart_fixture: respx.Router):
+    """If page 1 is already short and totleSize matches, no second page is fetched."""
+    page1 = _page_body([_trip(1), _trip(2)], total=2, page_size=20)
+
+    captured: list[httpx.Request] = []
+
+    def _dispatch(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=page1)
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        smart_fixture.get(
+            re.compile(re.escape(base + _JOURNAL_PATH + "TestVIN0000000001") + r".*")
+        ).mock(side_effect=_dispatch)
+
+    account = await prepare_account_with_vehicles()
+    pre_count = len(captured)
+    merged = await account.get_trip_journal("TestVIN0000000001")
+
+    # Only one journal request should have been issued by THIS call —
+    # `prepare_account_with_vehicles` made its own earlier ones.
+    new_calls = captured[pre_count:]
+    page_indices = [
+        int(parse_qs(urlparse(str(r.url)).query)["pageIndex"][0])
+        for r in new_calls
+    ]
+    assert page_indices == [1], "no page 2 expected: total reached and page is short"
+
+    assert len(merged["data"]["list"]) == 2
+
+
+@pytest.mark.parametrize(
+    ("total_raw", "expected_total"),
+    [
+        (3, 3),
+        (3.0, 3),
+        ("3", 3),
+        ("  3  ", 3),
+        ("3.0", None),
+        (None, None),
+        (True, None),
+        ("not a number", None),
+    ],
+    ids=["int", "float", "string_digit", "whitespace_padded", "string_float", "none", "bool_true", "garbage_string"],
+)
+def test_unwrap_journal_page_coerces_totlesize(total_raw, expected_total):
+    """``_unwrap_journal_page`` accepts stringified ``totleSize`` and rejects bools/floats-as-string."""
+    from pysmarthashtag.account import _unwrap_journal_page
+
+    body = {
+        "data": {
+            "pagination": {"totleSize": total_raw},
+            "list": [_trip(1), _trip(2)],
+        }
+    }
+    items, total = _unwrap_journal_page(body)
+    assert len(items) == 2
+    assert total == expected_total


### PR DESCRIPTION
Builds on the trip-journal foundation merged in #194 (same author). That PR added the page-1 fetch; this PR teaches the same method to walk subsequent pages when the cloud reports more entries than fit on page 1.

## Summary

`account.get_trip_journal` previously fetched only `pageIndex=1` (server caps at 20 entries) and returned whatever the cloud sent, even when `pagination.totleSize` reported more trips available. Accounts with deeper history saw silent truncation. This change loops `pageIndex=2..N` until `len(accumulated) >= totleSize`, the previous page is short, or the cloud signals end-of-data via code `8153` mid-loop, then returns the page-1 dict with `data.list` replaced by the merged accumulation and `data.pagination.totleSize` refreshed. Single-page accounts (the common case) are byte-identical to the prior behaviour.

## What's new

- `pysmarthashtag/account.py` — `get_trip_journal` gains two keyword-defaulted kwargs:
  ```
  async def get_trip_journal(self, vin, page_size=20, window_days=14,
                              raise_on_truncation=False, page_gap_seconds=0.0) -> dict
  ```
  Positional shape unchanged. Loops pages, merges `data.list` preserving the cloud's desc-by-time ordering across pages.
- New private helper `_fetch_journal_page` factored from the old single-page body. Same 3-retry semantics for `SmartTokenRefreshNecessary` / `SmartHumanCarConnectionError` as before.
- Module-level helpers `_is_benign_empty`, `_unwrap_journal_page` and constant `_BENIGN_EMPTY_CODE = "8153"`.
- `pysmarthashtag/models.py` — new `JournalTruncationError(SmartAPIError)`. Subclasses `SmartAPIError` so existing broad-except handlers still catch it; the distinct type lets backfill callers distinguish "transient cloud hiccup" from "page-loop terminated short" without string-matching messages.

## Behaviour

Loop termination conditions, evaluated before each `pageIndex=N` fetch:

1. `len(accumulated) >= totleSize` from the page-1 response — stop, return merged.
2. Previous page was short (`last_page_count < page_size`) — stop. Cloud has no more entries even if `totleSize` disagrees.
3. Mid-loop `code == 8153` — treat as end-of-data signal, stop without raising.
4. Mid-loop non-8153 error — propagate `httpx.HTTPStatusError`.
5. Mid-loop empty list (page returns `[]` but totleSize not yet reached) — stop.

Page-1 8153 still raises `httpx.HTTPStatusError`. This asymmetry is deliberate: `get_vehicles` has its own benign-empty handling around the page-1 call, so flipping page-1 semantics would silently shift error-handling responsibility. Mid-loop 8153 is the cloud's documented "no more data" signal, hence treated as a terminator.

`raise_on_truncation` decision tree when `len(accumulated) != totleSize` after the loop exits:

- `raise_on_truncation=False` (default): WARNING logged with VIN sanitized, partial merged response returned, `totleSize` preserved from the cloud's reported value.
- `raise_on_truncation=True`: `JournalTruncationError` raised with the accumulated/expected counts in the message.

Page-1 server failure still returns `{}` — matches the sibling `get_vehicle_ota_info` pattern and the prior single-page contract. The one subtle delta: page-1 success with empty/None `data.list` now returns the raw first-page dict instead of entering the loop. `TripJournal.from_response` in `pysmarthashtag/vehicle/journal.py` handles missing-list gracefully, so this is functionally equivalent.

## Backward compatibility

No caller breakage. Existing call sites passing `(vin)`, `(vin, page_size=...)`, or `(vin, page_size=..., window_days=...)` work unchanged — the new kwargs are defaulted. Return shape is still `dict` with `code`/`message`/`success`/`data`, and `data.list` + `data.pagination.totleSize` present. `TripJournal.from_response` only reads `data.list[0]` and `pagination.totleSize`, so the merged shape is invariant. `total_trips` now reflects the final cloud-reported total rather than the page-1 total — almost always identical; only differs if the cloud rotated total mid-loop, in which case the new value is strictly more correct. `get_vehicles`' internal call and its existing benign-empty handling (covered by `tests/test_journal.py`) are untouched. `JournalTruncationError` is opt-in via `raise_on_truncation=True`; default callers never see it.

## Why these defaults

**`raise_on_truncation=False`**: routine polling (consumer coordinators running every 60-300s) cannot afford a hard failure on a partial page — the next iteration picks up the missing trips. A WARNING surfaces the anomaly without breaking the user's setup. Backfill and archive callers — where silent loss IS worse than aborting — opt in with `raise_on_truncation=True`. This mirrors the existing pattern in `get_vehicles`, which catches journal errors with `_LOGGER.debug(exc_info=True)` rather than crashing the refresh for one bad vehicle.

**`page_gap_seconds=0.0`**: the SDK is a transport library, not a rate-limiter. Polite-API pacing is policy that belongs to the consumer — coordinators, batch backfill scripts, and interactive CLIs all want different gaps. Defaulting to 0 keeps single-page accounts (the common case) identical to pre-loop behaviour: zero added latency, zero behaviour change. Consumers who want pacing pass an explicit value, matching the pattern used elsewhere in the codebase (no built-in retry backoff in the existing request-retry loops either). The guard `if page_gap_seconds > 0` before `await asyncio.sleep(...)` is technically redundant — `asyncio.sleep(0)` is a documented event-loop yield — but it avoids the unnecessary scheduling round-trip on the default path.

## Test coverage

New file `pysmarthashtag/tests/test_journal_pagination.py` (260 lines, 7 respx-driven scenarios, every while-loop branch exercised):

- `test_loops_until_totleSize_reached` — 2-page loop, asserts merged order preserves cloud desc-by-time ordering across page boundaries and that `totleSize` matches.
- `test_short_page_stops_loop` — short page (1 item with `page_size=2`) terminates the loop even when `totleSize` claims more; verifies no `pageIndex=2` request is issued.
- `test_mid_loop_8153_breaks_loop` — `pageIndex=2` returns `code=8153`; no exception, returns page-1 accumulation.
- `test_mid_loop_other_error_propagates` — `pageIndex=2` returns `code=5000`; raises `httpx.HTTPStatusError`.
- `test_truncation_warn_when_count_disagrees` — default behaviour: WARNING logged, partial returned, `totleSize=10` preserved in the merged response.
- `test_truncation_raises_when_caller_opts_in` — `raise_on_truncation=True` raises `JournalTruncationError`.
- `test_no_loop_when_first_page_short` — page-1 returns 2 of 2 (total reached + short): no `pageIndex=2` issued.

Existing `tests/test_journal.py` continues to cover end-to-end `get_vehicles` → journal population and the page-1 8153 survival path, both still relevant after the refactor.

Known coverage gaps, called out for transparency: `page_gap_seconds` is not directly asserted (calls `asyncio.sleep` straight through); the `SmartTokenRefreshNecessary` / `SmartHumanCarConnectionError` retry path inside `_fetch_journal_page` is unchanged but uncovered (was uncovered before too); grant rotation mid-loop is not explicitly tested but relies on the existing inner retry. Happy to add any of these if reviewers want.

## Verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trip journal fetching now automatically retrieves multi-page results for complete journey histories
  * Added configurable options to control truncation handling and page-request timing

* **Bug Fixes**
  * Improved handling of cloud "data unavailable" responses and reconstruction of merged journal results
  * Consistent behavior when mid-stream pages are short or missing

* **Tests**
  * Added unit tests covering pagination, truncation, error scenarios, and response normalization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->