### PR TITLE
feat(state): add VehicleState dataclass for the GetCarState endpoint

### DIFF
--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -155,11 +155,21 @@ class SmartAccount:
                 _LOGGER.debug(
                     "Trip journal fetch failed for %s", sanitize_log_data(vin), exc_info=True
                 )
+            # Per-VIN TBox state flags (engine/journal/valet/etc.) — best-effort,
+            # same reasoning as the journal call above.
+            state_response = None
+            try:
+                state_response = await self.get_vehicle_state(vin)
+            except Exception:  # noqa: BLE001  # Best-effort: state fetch must not break refresh.
+                _LOGGER.debug(
+                    "Vehicle-state fetch failed for %s", sanitize_log_data(vin), exc_info=True
+                )
             vehicle.combine_data(
                 vehicle_info,
                 charging_settings=vehicle_soc,
                 ota_info=vehicle_ota_info,
                 journal_response=journal_response,
+                state_response=state_response,
             )
 
     async def select_active_vehicle(self, vin) -> None:
@@ -240,6 +250,47 @@ class SmartAccount:
                 break
             if retry > 1:
                 raise SmartAuthError("Could not get vehicle information")
+        return data
+
+    async def get_vehicle_state(self, vin) -> dict:
+        """Fetch the small flat-dict state-flag response for a vehicle.
+
+        Hits ``/remote-control/vehicle/status/state/{vin}`` (no params) —
+        the same endpoint Hello # uses to confirm command dispatch (e.g.
+        polls ``journalLogState`` after toggling 'Record trips on vehicle').
+
+        Returns the raw response dict; caller wraps via
+        ``VehicleState.from_response()``. Errors are logged but not raised
+        so a single flaky vehicle doesn't break the wider refresh.
+        """
+        _LOGGER.debug("Getting vehicle state for %s", sanitize_log_data(vin))
+        path = "/remote-control/vehicle/status/state/" + vin
+        data: dict = {}
+        async with SmartClient(self.config) as client:
+            for retry in range(3):
+                try:
+                    r_state = await client.get(
+                        self.vehicles[vin].base_url + path,
+                        headers={
+                            **utils.generate_default_header(
+                                client.config.authentication.device_id,
+                                client.config.authentication.api_access_token,
+                                params={},
+                                method="GET",
+                                url=path,
+                            )
+                        },
+                    )
+                    _LOGGER.debug("Got response %d", r_state.status_code)
+                    data = r_state.json()
+                except SmartTokenRefreshNecessary:
+                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    continue
+                except SmartHumanCarConnectionError:
+                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                    await self.select_active_vehicle(vin)
+                    continue
+                break
         return data
 
     async def get_vehicle_soc(self, vin) -> str:

--- a/pysmarthashtag/tests/test_vehicle_state.py
+++ b/pysmarthashtag/tests/test_vehicle_state.py
@@ -1,0 +1,104 @@
+"""Tests for VehicleState — the GetCarState parser."""
+
+from datetime import datetime
+
+from pysmarthashtag.vehicle.vehicle_state import VehicleState
+
+
+CANONICAL_RESPONSE = {
+    "code": "1000",
+    "data": {
+        "svtState": 1,
+        "parkComfortState": 1,
+        "btActive": 0,
+        "valetModeState": 0,
+        "pulseHeatActive": 0,
+        "btTempActive": 0,
+        "carLocatorActive": 1,
+        "campingModeActive": 0,
+        "nextWakeupTime": "1706002216000",  # epoch ms as string (real prod format)
+        "driftModeActive": 0,
+        "engineState": 0,
+        "powerMode": "1",
+        "positionUploadState": 1,
+        "journalLogState": 0,
+        "vstdState": 2,
+        "overheatState": 1,
+        "privacyMode": 0,
+        "pncStatus": 0,
+        "chatVideoMainActive": 0,
+        "washCarModeActive": 0,
+        "vin": "HESYA4C43SG204913",
+    },
+    "success": True,
+    "hint": None,
+    "httpStatus": "OK",
+    "sessionId": "deadbeef",
+    "message": "operation succeed",
+}
+
+
+def test_from_response_unwraps_envelope():
+    """The envelope {code,data,success,...} is unwrapped to .data."""
+    s = VehicleState.from_response(CANONICAL_RESPONSE)
+    assert s is not None
+    assert s.journal_log_state == 0
+    assert s.position_upload_state == 1
+    assert s.car_locator_active == 1
+    assert s.svt_state == 1
+    assert s.vin == "HESYA4C43SG204913"
+
+
+def test_from_response_accepts_unwrapped_data():
+    """Calling with just the inner data dict works too."""
+    s = VehicleState.from_response(CANONICAL_RESPONSE["data"])
+    assert s is not None
+    assert s.engine_state == 0
+    assert s.power_mode == "1"
+    assert s.privacy_mode == 0
+
+
+def test_next_wakeup_time_decoded():
+    """Epoch-ms string decodes to a TZ-aware UTC datetime (~Jan 23, 2024 in this fixture)."""
+    s = VehicleState.from_response(CANONICAL_RESPONSE)
+    assert isinstance(s.next_wakeup_time, datetime)
+    assert s.next_wakeup_time.year == 2024
+    # Must be timezone-aware — HA TIMESTAMP device_class rejects naive datetimes.
+    assert s.next_wakeup_time.tzinfo is not None
+
+
+def test_next_wakeup_time_handles_garbage():
+    """A non-numeric nextWakeupTime is silently dropped, not exception."""
+    payload = dict(CANONICAL_RESPONSE["data"])
+    payload["nextWakeupTime"] = "not-a-timestamp"
+    s = VehicleState.from_response(payload)
+    assert s is not None
+    assert s.next_wakeup_time is None
+
+
+def test_from_response_handles_none():
+    assert VehicleState.from_response(None) is None
+    assert VehicleState.from_response("not a dict") is None  # type: ignore[arg-type]
+
+
+def test_from_response_handles_empty():
+    assert VehicleState.from_response({}) is None
+    # Envelope with no data still returns None (rather than empty VehicleState)
+    assert VehicleState.from_response({"code": "8153", "data": None}) is None
+
+
+def test_from_response_handles_partial_data():
+    """Missing fields silently become None; doesn't blow up."""
+    s = VehicleState.from_response({"data": {"journalLogState": 1}, "code": "1000"})
+    assert s is not None
+    assert s.journal_log_state == 1
+    assert s.engine_state is None
+    assert s.privacy_mode is None
+
+
+def test_journal_log_state_flip_detection():
+    """Practical use: did the toggle flip between two snapshots?"""
+    before = VehicleState.from_response({"data": {"journalLogState": 0}, "code": "1000"})
+    after = VehicleState.from_response({"data": {"journalLogState": 1}, "code": "1000"})
+    assert before.journal_log_state != after.journal_log_state
+    assert after.journal_log_state == 1

--- a/pysmarthashtag/tests/test_vehicle_state.py
+++ b/pysmarthashtag/tests/test_vehicle_state.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from pysmarthashtag.vehicle.vehicle_state import VehicleState
 
-
 CANONICAL_RESPONSE = {
     "code": "1000",
     "data": {
@@ -77,11 +76,13 @@ def test_next_wakeup_time_handles_garbage():
 
 
 def test_from_response_handles_none():
+    """None / non-dict input must not blow up."""
     assert VehicleState.from_response(None) is None
     assert VehicleState.from_response("not a dict") is None  # type: ignore[arg-type]
 
 
 def test_from_response_handles_empty():
+    """Empty body / null data envelope returns None, not an empty VehicleState."""
     assert VehicleState.from_response({}) is None
     # Envelope with no data still returns None (rather than empty VehicleState)
     assert VehicleState.from_response({"code": "8153", "data": None}) is None
@@ -97,7 +98,7 @@ def test_from_response_handles_partial_data():
 
 
 def test_journal_log_state_flip_detection():
-    """Practical use: did the toggle flip between two snapshots?"""
+    """Detect a toggle flip between two snapshots."""
     before = VehicleState.from_response({"data": {"journalLogState": 0}, "code": "1000"})
     after = VehicleState.from_response({"data": {"journalLogState": 1}, "code": "1000"})
     assert before.journal_log_state != after.journal_log_state

--- a/pysmarthashtag/vehicle/vehicle.py
+++ b/pysmarthashtag/vehicle/vehicle.py
@@ -14,6 +14,7 @@ from pysmarthashtag.vehicle.position import Position
 from pysmarthashtag.vehicle.running import Running
 from pysmarthashtag.vehicle.safety import Safety
 from pysmarthashtag.vehicle.tires import Tires
+from pysmarthashtag.vehicle.vehicle_state import VehicleState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +60,10 @@ class SmartVehicle:
 
     last_trip: Optional[TripJournal] = None
     """The most recent trip from the journal log (server-side reverse-geocoded)."""
+
+    state: Optional[VehicleState] = None
+    """Per-VIN TBox-side state flags from the GetCarState endpoint
+    (journal recording, valet mode, privacy, next wakeup, etc.)."""
 
     climate_control: Optional["ClimateControll"] = None  # noqa: F821
 
@@ -110,6 +115,7 @@ class SmartVehicle:
         ota_info: Optional[dict] = None,
         fetched_at: Optional[datetime.datetime] = None,
         journal_response: Optional[dict] = None,
+        state_response: Optional[dict] = None,
     ) -> dict:
         """Combine all data into one dictionary."""
         self.data.update(vehicle_base)
@@ -134,6 +140,10 @@ class SmartVehicle:
             # Other endpoints (e.g. status, SOC, OTA) call combine_data without
             # this kwarg and must not blow away an already-populated trip.
             self.last_trip = TripJournal.from_response(journal_response)
+        if state_response is not None:
+            # Same best-effort overwrite semantics as last_trip — only refresh
+            # when the GetCarState fetch actually succeeded for this poll.
+            self.state = VehicleState.from_response(state_response)
 
         from pysmarthashtag.control.climate import ClimateControll
 

--- a/pysmarthashtag/vehicle/vehicle_state.py
+++ b/pysmarthashtag/vehicle/vehicle_state.py
@@ -1,0 +1,169 @@
+"""VehicleState model — parses the GetCarState endpoint response.
+
+The smart cloud exposes a small flat-dict state-flag endpoint that's
+distinct from the big ``/remote-control/vehicle/status/{vin}`` payload
+that ``Battery``/``Maintenance``/etc. parse. Hello # uses this endpoint
+to confirm command dispatch (e.g. polls ``journalLogState`` after
+flipping the trip-recording toggle).
+
+Source endpoint:
+    GET /remote-control/vehicle/status/state/{vin}    (no params)
+
+Response shape (envelope is the standard ``{code, data, success, …}``):
+    {"data": {"journalLogState": 0,
+              "positionUploadState": 1,
+              "carLocatorActive": 1,
+              "engineState": 0,
+              "powerMode": "1",
+              "nextWakeupTime": "1706002216000",
+              "valetModeState": 0,
+              "campingModeActive": 0, "driftModeActive": 0,
+              "washCarModeActive": 0, "chatVideoMainActive": 0,
+              "parkComfortState": 1, "privacyMode": 0,
+              "pulseHeatActive": 0, "overheatState": 0,
+              "btActive": 0, "btTempActive": 0,
+              "svtState": 1, "pncStatus": 0,
+              "vstdState": 2,
+              "vin": "..."}}
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from pysmarthashtag.models import VehicleDataBase, get_field_as_type
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class VehicleState(VehicleDataBase):
+    """Per-VIN TBox-side state flags from the GetCarState endpoint."""
+
+    journal_log_state: Optional[int] = None
+    """Trip recording on the TBox (0=off, 1=on). Toggled by Hello #'s
+    'Record trips on vehicle' setting; required for ``journalLogV4`` to
+    return populated trip data."""
+
+    position_upload_state: Optional[int] = None
+    """TBox uploading GPS position to cloud (0=off, 1=on)."""
+
+    car_locator_active: Optional[int] = None
+    """Car-locator GPS service active (0=off, 1=on)."""
+
+    next_wakeup_time: Optional[datetime] = None
+    """Next scheduled TBox wakeup. Useful operationally — remote commands
+    sent before this time may be slow (TBox is asleep) or queued."""
+
+    engine_state: Optional[int] = None
+    """Engine on/off (0=off, 1=on). Note: integer encoding here is distinct
+    from the string ``engineStatus`` (\"engine_off\" / \"engine_on\") in
+    the full ``/vehicle/status/{vin}`` response."""
+
+    power_mode: Optional[str] = None
+    """Power mode reported as a string (e.g. \"0\", \"1\", \"2\")."""
+
+    valet_mode_state: Optional[int] = None
+    """Valet mode active (0=off, 1=on)."""
+
+    camping_mode_active: Optional[int] = None
+    """Camping mode (climate keeps running while parked)."""
+
+    drift_mode_active: Optional[int] = None
+    """Drift mode (Smart 5 Brabus performance feature)."""
+
+    wash_car_mode_active: Optional[int] = None
+    """Car-wash mode (sensors/windows prepped for car wash)."""
+
+    chat_video_main_active: Optional[int] = None
+    """In-car video-chat / front-camera mode active."""
+
+    park_comfort_state: Optional[int] = None
+    """Park-comfort climate mode."""
+
+    privacy_mode: Optional[int] = None
+    """Privacy mode (cameras/microphones disabled)."""
+
+    pulse_heat_active: Optional[int] = None
+    """Battery pulse-heating active (winter preconditioning)."""
+
+    overheat_state: Optional[int] = None
+    """Cabin overheat protection currently active."""
+
+    bt_active: Optional[int] = None
+    """Bluetooth main session active."""
+
+    bt_temp_active: Optional[int] = None
+    """Bluetooth temporary session active."""
+
+    svt_state: Optional[int] = None
+    """Stolen Vehicle Tracking subsystem state."""
+
+    pnc_status: Optional[int] = None
+    """Plug-and-Charge contract status."""
+
+    vstd_state: Optional[int] = None
+    """VSTD subsystem state. Read from GetCarState; exact semantics are not
+    fully reverse-engineered, surfaced as best-effort for downstream consumers
+    that may have observed it in their own captures."""
+
+    vin: Optional[str] = None
+    """VIN echoed by the cloud (sanity check that response is for the
+    requested vehicle)."""
+
+    @classmethod
+    def from_response(cls, response: Any) -> Optional["VehicleState"]:
+        """Build a VehicleState from a GetCarState response body.
+
+        Accepts either the full envelope ``{code, data: {...}, success, …}``
+        or the unwrapped ``data`` dict directly. Returns ``None`` when the
+        response is empty / malformed / a non-success error envelope.
+        """
+        if not isinstance(response, dict):
+            return None
+        # If it's a response envelope (has top-level "code"), require a
+        # non-empty dict in "data" — otherwise return None (covers error
+        # envelopes like {"code": "8153", "data": null}).
+        if "code" in response:
+            data = response.get("data")
+            if not isinstance(data, dict) or not data:
+                return None
+        else:
+            data = response
+        if not data:
+            return None
+
+        next_wake: Optional[datetime] = None
+        nw = data.get("nextWakeupTime")
+        if nw is not None:
+            try:
+                # Cloud reports as epoch milliseconds, sometimes as a string.
+                # Use UTC-aware datetime so HA's TIMESTAMP device_class accepts it.
+                next_wake = datetime.fromtimestamp(int(nw) / 1000, tz=timezone.utc)
+            except (TypeError, ValueError):
+                _LOGGER.debug("nextWakeupTime not parseable: %r", nw)
+
+        return cls(
+            journal_log_state=get_field_as_type(data, "journalLogState", int),
+            position_upload_state=get_field_as_type(data, "positionUploadState", int),
+            car_locator_active=get_field_as_type(data, "carLocatorActive", int),
+            next_wakeup_time=next_wake,
+            engine_state=get_field_as_type(data, "engineState", int),
+            power_mode=get_field_as_type(data, "powerMode", str),
+            valet_mode_state=get_field_as_type(data, "valetModeState", int),
+            camping_mode_active=get_field_as_type(data, "campingModeActive", int),
+            drift_mode_active=get_field_as_type(data, "driftModeActive", int),
+            wash_car_mode_active=get_field_as_type(data, "washCarModeActive", int),
+            chat_video_main_active=get_field_as_type(data, "chatVideoMainActive", int),
+            park_comfort_state=get_field_as_type(data, "parkComfortState", int),
+            privacy_mode=get_field_as_type(data, "privacyMode", int),
+            pulse_heat_active=get_field_as_type(data, "pulseHeatActive", int),
+            overheat_state=get_field_as_type(data, "overheatState", int),
+            bt_active=get_field_as_type(data, "btActive", int),
+            bt_temp_active=get_field_as_type(data, "btTempActive", int),
+            svt_state=get_field_as_type(data, "svtState", int),
+            pnc_status=get_field_as_type(data, "pncStatus", int),
+            vstd_state=get_field_as_type(data, "vstdState", int),
+            vin=get_field_as_type(data, "vin", str),
+        )


### PR DESCRIPTION
## Summary

Adds a new read-only API surface for the `GetCarState` endpoint that the official app polls after toggling vehicle state (trip recording, valet mode, etc.). The endpoint returns a flat dictionary of ~21 scalar status flags distinct from the larger nested `GetCar` payload. This wraps the response in a `VehicleState` dataclass, fetches it best-effort on each `get_vehicles()` refresh, and attaches it to `SmartVehicle.state` for downstream consumers.

The primary motivation is to pair with `journalLogV4` (PR #194, now merged — context only): after the trip-journal switch flips, this endpoint exposes the TBox's own `journalLogState` flag so a downstream switch can verify the toggle actually took effect rather than blindly trusting the command-dispatch response.

## Endpoint specifics

- **Path:** `/remote-control/vehicle/status/state/{vin}` (joined onto `self.vehicles[vin].base_url`, so V1/V2 base URLs are honored per vehicle)
- **Method:** `GET`, no query params, no userId, no authorization-grant POST
- **Headers:** standard `generate_default_header(device_id, api_access_token, params={}, method="GET", url=path)` — same HMAC signing as every other authed endpoint
- **Response shape:** standard envelope `{code, data: {...}, success, hint, httpStatus, sessionId, message}`. The `data` dict is **flat** (no nested status sections), with ~21 scalar fields
- **Error envelope:** cloud returns `{"code": "8153", "data": null}` for vehicles with the endpoint disabled; parser treats this as `None` (not an empty dataclass) so consumers can distinguish "no state available" from "all flags zero"

Unlike `journalLogV4`, this endpoint takes no rotating grant and has no per-VIN cache to invalidate — it's a simple side-effect-free read. No grant rotation, no token-cache contention, no per-VIN auth state.

## New API surface

1. **`pysmarthashtag.vehicle.vehicle_state.VehicleState`** — `@dataclass(VehicleDataBase)` with 21 `Optional[...]` fields. Classmethod `from_response(response: Any) -> Optional["VehicleState"]` accepts either the full envelope (unwraps `data`) or an already-unwrapped `data` dict; returns `None` for non-dict input, empty dict, or error envelopes.

2. **`SmartAccount.get_vehicle_state(self, vin) -> dict`** — async fetcher returning the raw response dict (caller wraps via `VehicleState.from_response()`). Three-retry loop catching `SmartTokenRefreshNecessary` (refresh + retry) and `SmartHumanCarConnectionError` (re-select active vehicle + retry). Returns `{}` on exhausted retries rather than raising. Mirrors `get_trip_journal()` exactly.

3. **`SmartVehicle.state: Optional[VehicleState] = None`** — class-level attribute slot populated via a new `state_response: Optional[dict] = None` kwarg in `combine_data`.

4. **`SmartAccount.get_vehicles()` refresh loop** — calls `get_vehicle_state(vin)` wrapped in `try/except Exception` (best-effort, errors logged at DEBUG only) and passes the result through `combine_data(..., state_response=state_response)`. A flaky vehicle does not break the wider refresh.

## Field-by-field breakdown

**Telemetry / recording:** `journal_log_state` (the headline field — flips 0→1 when trip recording activates), `position_upload_state`, `car_locator_active`, `engine_state`, `power_mode`.

**Special modes:** `valet_mode_state`, `camping_mode_active`, `drift_mode_active`, `wash_car_mode_active`, `chat_video_main_active`, `park_comfort_state`, `privacy_mode`.

**Thermal:** `pulse_heat_active`, `overheat_state`, `bt_active` (battery-thermal), `bt_temp_active`.

**Connectivity / security:** `next_wakeup_time`, `svt_state`, `pnc_status`, `vstd_state` (VSTD subsystem state — read from GetCarState; exact semantics not yet reverse-engineered, surfaced as best-effort for downstream consumers that may have observed it in their own captures), `vin` (echo-back sanity check).

## Type choices

- **`Optional[int]` for 0/1 flags, not `Optional[bool]`** — matches the existing convention in `Running` (~25 light/status flags also typed `Optional[int]`). The cloud sends raw `0`/`1` integers; coercing to `bool` would lose the ability to distinguish `0` from `None` in downstream sensor display and would diverge from `Battery`/`Running`/`Maintenance` style. Some fields (e.g. `vstd_state: 2`) are also wider than 0/1.

- **`Optional[str]` for `power_mode`** — the cloud emits `"1"` as a quoted string. Coercing to int would silently drop any future non-numeric mode value; string round-trips the wire format faithfully.

- **`Optional[datetime]` for `next_wakeup_time`** — cloud reports as **epoch milliseconds as a string** (canonical fixture: `"1706002216000"`). Code does `datetime.fromtimestamp(int(nw) / 1000, tz=timezone.utc)`. Result is deliberately **TZ-aware UTC** — downstream TIMESTAMP device_classes reject naive datetimes. `TypeError`/`ValueError` from `int(nw)` are caught and the field is left `None` with a DEBUG line; garbage like `"not-a-timestamp"` will not raise.

- **`engine_state` naming gotcha** documented in the field docstring: this is `int` (0/1), distinct from the `engineStatus` STRING field (`"engine_off"`/`"engine_on"`) in the big GetCar payload. Two encodings for the same physical fact under two attribute names.

## Best-effort fetch

The `get_vehicle_state(vin)` call in `get_vehicles()` is wrapped in `try/except Exception` (with `# noqa: BLE001` and inline rationale). If the call fails, `state_response` stays `None`, and `combine_data` skips the assignment branch — preserving any previously cached `vehicle.state` rather than blowing it away (same semantics as `last_trip`). One flaky vehicle does not break refresh for the others.

## Test coverage

`pysmarthashtag/tests/test_vehicle_state.py` — 8 tests, all dataclass-level units:

1. `test_from_response_unwraps_envelope` — full `{code, data, success, ...}` envelope unwraps; verifies `journal_log_state`, `position_upload_state`, `car_locator_active`, `svt_state`, `vin`.
2. `test_from_response_accepts_unwrapped_data` — already-unwrapped `data` dict works too; asserts `engine_state`, `power_mode`, `privacy_mode`.
3. `test_next_wakeup_time_decoded` — epoch-ms string decodes to datetime, year is 2024, `tzinfo is not None`.
4. `test_next_wakeup_time_handles_garbage` — `"not-a-timestamp"` silently yields `next_wakeup_time=None`.
5. `test_from_response_handles_none` — `None`/non-dict input returns `None`.
6. `test_from_response_handles_empty` — `{}` and the real `{"code":"8153","data":null}` envelope both return `None`.
7. `test_from_response_handles_partial_data` — missing fields silently become `None`.
8. `test_journal_log_state_flip_detection` — practical use case: comparing two snapshots detects a 0→1 toggle flip.

## Backward compatibility

Purely additive on the pysmarthashtag side. The `state` attribute is a class-level default of `None`, so any code that touches `vehicle.state` on an older payload gracefully sees `None`. No existing dataclass fields, function signatures, or wire calls are modified.

For downstream consumers: a wheel built from this branch is required — guards like `vehicle.state is None` evaluate cleanly on this branch (the class attribute resolves), but the same expression against a pre-branch install will raise `AttributeError` before `is None` can run. Defensive consumers should prefer `getattr(vehicle, "state", None) is None` when supporting mixed installs.

## Verification

- `ruff check pysmarthashtag/` — clean
- `pytest pysmarthashtag/tests/ -q` — **119 tests pass** (111 existing + 8 new)
- Live probe against the cloud confirms the canonical fixture matches real responses

## Stacked / dependencies

**Independent.** Sits directly on `upstream/main` at `a49f0a6`. PR #194 (`feat/trip-journal`) is **already merged** and is context only — no rebase, no stacked-PR dance needed. The pairing argument with `journalLogV4` is actually stronger now that #194 has landed: this endpoint confirms the bit that the trip-journal switch flips.