### PR TITLE
feat(trackpoints): add per-trip GPS trackpoints endpoint

### DIFF
--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -6,17 +6,57 @@ import logging
 from dataclasses import InitVar, dataclass, field
 from typing import Optional
 
+import httpx
+
 from pysmarthashtag.api import utils
 from pysmarthashtag.api.authentication import SmartAuthentication
 from pysmarthashtag.api.client import SmartClient, SmartClientConfiguration
 from pysmarthashtag.api.log_sanitizer import sanitize_log_data
 from pysmarthashtag.const import API_CARS_URL, API_SELECT_CAR_URL, EndpointUrls
 from pysmarthashtag.models import SmartAuthError, SmartHumanCarConnectionError, SmartTokenRefreshNecessary
+from pysmarthashtag.vehicle.trackpoints import TripTrackpoints, parse_trackpoints_response
 from pysmarthashtag.vehicle.vehicle import SmartVehicle
+
+# Path prefix for the per-trip GPS trackpoints endpoint. Cloud-side
+# service is ``vehicle-history-service / journal-service`` (same
+# ``apiv2.ecloudeu.com`` host as journalLogV4); the trailing ``history``
+# segment is the cloud's own naming.
+TRIP_TRACKPOINTS_PATH_PREFIX = "/vehicle-history-service/journal-service/vehicle/status/history/"
+
+# Default page size for the trackpoints endpoint, matching the cap the
+# cloud advertises in its own ``pagination`` block. In observed responses
+# ``totleSize`` never exceeded this cap; the wrapper logs a WARNING if it
+# ever does so a future maintainer knows to add pagination here.
+TRIP_TRACKPOINTS_PAGE_SIZE = 500
+
+# Cloud status code returned by both journalLogV4 and the trackpoints
+# endpoint when there's no data to report. The SDK raises
+# :class:`httpx.HTTPStatusError` for any non-1000 code with a
+# ``message`` key; 8153 surfaces here so callers can normalise it to an
+# empty result without propagating to the caller.
+_BENIGN_EMPTY_CODE = "8153"
 
 VALID_UNTIL_OFFSET = datetime.timedelta(seconds=10)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _is_benign_empty(exc: httpx.HTTPStatusError) -> bool:
+    """Return True iff ``exc`` carries the cloud's 8153 "data unavailable" code.
+
+    The SDK's :func:`raise_for_status_event_handler` raises for any
+    non-1000 ``code`` with a ``message`` key. ``8153`` is the cloud's
+    end-of-data signal for journal endpoints — callers normalise it to
+    an empty result rather than propagating it as an error.
+    """
+    response = exc.response
+    if response is None:
+        return False
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+    return str(body.get("code")) == _BENIGN_EMPTY_CODE
 
 
 @dataclass
@@ -419,6 +459,103 @@ class SmartAccount:
                     continue
                 break
         return data
+
+    async def get_trip_trackpoints(
+        self,
+        vin: str,
+        start_time_ms: int,
+        end_time_ms: int,
+        page_size: int = TRIP_TRACKPOINTS_PAGE_SIZE,
+    ) -> TripTrackpoints:
+        """Fetch the per-trip GPS trackpoints for one finished trip.
+
+        Hits ``/vehicle-history-service/journal-service/vehicle/status/history/{vin}``
+        on the same host as journalLogV4, with the ``(startTime, endTime)``
+        window identifying the trip (the cloud has no separate trip-id
+        for this endpoint — the time window IS the identifier).
+
+        Unlike :meth:`get_trip_journal`, this endpoint does NOT require
+        :meth:`grant_journal_authorization` — calling that defensively
+        before each fetch would burn an extra cloud round-trip per trip.
+        The minimum required flow is auth (already done by
+        :meth:`get_vehicles` at session startup) plus the single signed
+        ``GET`` to ``/.../history/{VIN}``.
+
+        Cloud direction is ``desc`` (newest-first); the returned
+        :attr:`TripTrackpoints.points` are reversed to chronological
+        order so callers don't need to know the wire format.
+
+        Three benign-empty cloud responses all map to
+        ``TripTrackpoints(points=[], total_size=0)``:
+
+        * ``code: "1000"`` with ``data.list = []``
+        * ``code: "1000"`` with ``data: null``
+        * ``code: "8153"`` ("data unavailable" — surfaces as
+          :class:`httpx.HTTPStatusError` from the SDK)
+
+        Other ``HTTPStatusError`` exceptions (cloud 5xx, network,
+        non-1402 auth failure) propagate up so the caller can decide
+        whether to retry or surface the error.
+
+        Pagination is intentionally NOT implemented: the cloud's own
+        ``pagination`` block reports ``pageSize=500`` as the cap, and in
+        observed responses ``totleSize`` never exceeded it. If a future
+        trip ever does, this method logs a WARNING so we know to revisit.
+        """
+        _LOGGER.debug("Getting trip trackpoints for vehicle")
+        params = {
+            "endTime": str(end_time_ms),
+            "pageIndex": "0",
+            "pageSize": str(page_size),
+            "source": "tc",
+            "startTime": str(start_time_ms),
+        }
+        path = TRIP_TRACKPOINTS_PATH_PREFIX + vin
+        url = path + "?" + utils.join_url_params(params)
+        async with SmartClient(self.config) as client:
+            for retry in range(3):
+                try:
+                    response = await client.get(
+                        self.vehicles[vin].base_url + url,
+                        headers={
+                            **utils.generate_default_header(
+                                client.config.authentication.device_id,
+                                client.config.authentication.api_access_token,
+                                params=params,
+                                method="GET",
+                                url=path,
+                            )
+                        },
+                    )
+                    _LOGGER.debug("Got response %d", response.status_code)
+                    body = response.json()
+                except SmartTokenRefreshNecessary:
+                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    continue
+                except SmartHumanCarConnectionError:
+                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                    await self.select_active_vehicle(vin)
+                    continue
+                except httpx.HTTPStatusError as exc:
+                    if _is_benign_empty(exc):
+                        _LOGGER.debug(
+                            "trackpoints endpoint returned 8153 (data unavailable) for %s; treating as empty",
+                            sanitize_log_data(vin),
+                        )
+                        return TripTrackpoints(points=[], total_size=0)
+                    raise
+                break
+        trackpoints = parse_trackpoints_response(body)
+        if trackpoints.total_size > page_size:
+            _LOGGER.warning(
+                "Trackpoints page-size cap exceeded for %s: totleSize=%d > pageSize=%d. "
+                "Wrapper does not loop pageIndex; returned points are the head only. "
+                "Add pagination if this fires for real trips.",
+                sanitize_log_data(vin),
+                trackpoints.total_size,
+                page_size,
+            )
+        return trackpoints
 
     async def get_vehicle_ota_info(self, vin) -> dict:
         """Get information about a vehicle from OTA server."""

--- a/pysmarthashtag/tests/common.py
+++ b/pysmarthashtag/tests/common.py
@@ -107,6 +107,22 @@ class SmartMockRouter(respx.MockRouter):
                 200,
                 json=load_response(RESPONSE_DIR / "soc_90.json"),
             )
+            # Per-trip GPS-trackpoints endpoint takes
+            # endTime/startTime/pageIndex/pageSize/source query params.
+            # Match by regex prefix so the route fires regardless of
+            # param values.
+            self.get(re.compile(re.escape(
+                base_url + "/vehicle-history-service/journal-service/vehicle/status/history/TestVIN0000000001"
+            ) + r".*")).respond(
+                200,
+                json=load_response(RESPONSE_DIR / "trackpoints_response.json"),
+            )
+            self.get(re.compile(re.escape(
+                base_url + "/vehicle-history-service/journal-service/vehicle/status/history/TestVIN0000000002"
+            ) + r".*")).respond(
+                200,
+                json=load_response(RESPONSE_DIR / "trackpoints_response.json"),
+            )
             # journalLogV4 takes endTime/startTime/pageIndex/pageSize/userId
             # query params; respx matches by URL prefix without query when
             # we use route() with `host=` + `path__startswith=`. Keep

--- a/pysmarthashtag/tests/replys/trackpoints_response.json
+++ b/pysmarthashtag/tests/replys/trackpoints_response.json
@@ -1,0 +1,20 @@
+{
+  "code": "1000",
+  "message": null,
+  "data": {
+    "pagination": {
+      "pageIndex": 1,
+      "sortField": "startTime",
+      "start": 1,
+      "pageSize": 500,
+      "totleSize": 4,
+      "direction": "desc"
+    },
+    "list": [
+      {"basicVehicleStatus": {"position": {"latitude": 217471769, "longitude": 80503026}}},
+      {"basicVehicleStatus": {"position": {"latitude": 217470945, "longitude": 80502024}}},
+      {"basicVehicleStatus": {"position": {"latitude": 217469078, "longitude": 80504125}}},
+      {"basicVehicleStatus": {"position": {"latitude": 217468000, "longitude": 80505500}}}
+    ]
+  }
+}

--- a/pysmarthashtag/tests/test_trackpoints.py
+++ b/pysmarthashtag/tests/test_trackpoints.py
@@ -1,0 +1,256 @@
+"""Tests for the per-trip GPS-trackpoints endpoint and parser."""
+
+import logging
+import re
+
+import httpx
+import pytest
+import respx
+
+from pysmarthashtag.account import (
+    TRIP_TRACKPOINTS_PAGE_SIZE,
+    TRIP_TRACKPOINTS_PATH_PREFIX,
+)
+from pysmarthashtag.const import API_BASE_URL, API_BASE_URL_V2
+from pysmarthashtag.tests import RESPONSE_DIR, load_response
+from pysmarthashtag.tests.conftest import prepare_account_with_vehicles
+from pysmarthashtag.vehicle.trackpoints import (
+    Trackpoint,
+    TripTrackpoints,
+    parse_trackpoints_response,
+)
+
+# Cloud reports lat/lon in milliarcseconds; consumers see decimal degrees.
+_MAS_PER_DEGREE = 3_600_000.0
+
+
+def test_parse_handles_none_and_non_dict():
+    """A None or non-dict input must yield an empty result, not crash."""
+    assert parse_trackpoints_response(None) == TripTrackpoints(points=[], total_size=0)
+    assert parse_trackpoints_response("not a dict") == TripTrackpoints(points=[], total_size=0)  # type: ignore[arg-type]
+
+
+def test_parse_handles_empty_data_block():
+    """``data: null`` (alternate cloud-side empty shape) → empty result."""
+    assert parse_trackpoints_response({"code": "1000", "data": None}) == TripTrackpoints(
+        points=[], total_size=0
+    )
+
+
+def test_parse_handles_empty_list_with_zero_total():
+    """``code 1000`` with ``data.list = []`` and ``totleSize: 0`` → empty result."""
+    parsed = parse_trackpoints_response(
+        {
+            "code": "1000",
+            "data": {"pagination": {"totleSize": 0}, "list": []},
+        }
+    )
+    assert parsed.points == []
+    assert parsed.total_size == 0
+
+
+def test_parse_reverses_to_chronological_order():
+    """Reverse cloud's desc list to chronological so ``points[0]`` is trip start.
+
+    Cloud sends ``direction=desc`` (newest-first); we reverse at the
+    parser boundary so every consumer sees the same orientation.
+    """
+    body = load_response(RESPONSE_DIR / "trackpoints_response.json")
+    parsed = parse_trackpoints_response(body)
+    assert parsed.total_size == 4
+    # Fixture's wire-order list[0] (newest) lat=217471769; last entry's
+    # lat=217468000. Chronological reversal → points[0].lat comes from
+    # the wire-order LAST entry.
+    assert parsed.points[0].lat == pytest.approx(217468000 / _MAS_PER_DEGREE)
+    assert parsed.points[0].lon == pytest.approx(80505500 / _MAS_PER_DEGREE)
+    assert parsed.points[-1].lat == pytest.approx(217471769 / _MAS_PER_DEGREE)
+    assert parsed.points[-1].lon == pytest.approx(80503026 / _MAS_PER_DEGREE)
+
+
+def test_parse_milliarcsecond_to_degree_scaling():
+    """Cloud reports integer mas; parser divides by 3,600,000 for degrees."""
+    parsed = parse_trackpoints_response(
+        {
+            "code": "1000",
+            "data": {
+                "pagination": {"totleSize": 1},
+                "list": [
+                    {"basicVehicleStatus": {"position": {"latitude": 3_600_000, "longitude": 7_200_000}}}
+                ],
+            },
+        }
+    )
+    # 3 600 000 mas == 1.0 degree exactly.
+    assert parsed.points == [Trackpoint(lat=1.0, lon=2.0)]
+
+
+def test_parse_handles_degraded_per_point_payload():
+    """Degraded shapes yield ``Trackpoint(lat=None, lon=None)``, not crashes.
+
+    A missing ``basicVehicleStatus`` / ``position`` block, or non-dict
+    entries, must NOT drop the rest of the trip — sequence integrity
+    matters more than per-point completeness.
+    """
+    parsed = parse_trackpoints_response(
+        {
+            "code": "1000",
+            "data": {
+                "pagination": {"totleSize": 4},
+                "list": [
+                    "not-a-dict",
+                    {},
+                    {"basicVehicleStatus": "not-a-dict"},
+                    {"basicVehicleStatus": {"position": {"latitude": None, "longitude": None}}},
+                ],
+            },
+        }
+    )
+    # All four entries become null trackpoints; none is dropped.
+    assert len(parsed.points) == 4
+    for tp in parsed.points:
+        assert tp == Trackpoint(lat=None, lon=None)
+
+
+def test_parse_non_list_payload_coerces_to_empty():
+    """``data.list`` drifting to a non-list type yields empty points."""
+    parsed = parse_trackpoints_response(
+        {
+            "code": "1000",
+            "data": {
+                "pagination": {"totleSize": 0},
+                "list": {"unexpected": "shape"},
+            },
+        }
+    )
+    assert parsed.points == []
+    assert parsed.total_size == 0
+
+
+@pytest.mark.asyncio
+async def test_get_trip_trackpoints_returns_chronological_points(smart_fixture: respx.Router):
+    """End-to-end: ``get_trip_trackpoints()`` returns chronological points."""
+    account = await prepare_account_with_vehicles()
+    trackpoints = await account.get_trip_trackpoints(
+        "TestVIN0000000001", start_time_ms=1_000_000, end_time_ms=2_000_000
+    )
+    assert trackpoints.total_size == 4
+    assert len(trackpoints.points) == 4
+    # Same chronological-reversal assertion as the parser test.
+    assert trackpoints.points[0].lat == pytest.approx(217468000 / _MAS_PER_DEGREE)
+    assert trackpoints.points[-1].lat == pytest.approx(217471769 / _MAS_PER_DEGREE)
+
+
+@pytest.mark.asyncio
+async def test_get_trip_trackpoints_does_not_call_grant(smart_fixture: respx.Router):
+    """Trackpoints endpoint must NOT trigger ``authorization/insert``.
+
+    The cloud does not gate this call behind the per-session grant
+    handshake that ``journalLogV4`` requires; calling it defensively
+    per-fetch burns a cloud round-trip and risks transient 7065 errors
+    on back-to-back grants. Verify by counting calls on the auth-grant
+    route — registered for completeness in case the grant ever IS
+    introduced, currently dormant.
+    """
+    account = await prepare_account_with_vehicles()
+    # Register an auth-grant route so we can detect any call to it; the
+    # base SmartMockRouter doesn't ship one on this branch (no
+    # journalLogV4 route either — this branch predates PR #194).
+    grant_calls = []
+
+    def _track_grant(_request):
+        grant_calls.append(_request)
+        return httpx.Response(200, json={"code": "1000", "success": True})
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        smart_fixture.post(base + "/remote-control/user/authorization/insert").mock(
+            side_effect=_track_grant
+        )
+
+    await account.get_trip_trackpoints(
+        "TestVIN0000000001", start_time_ms=1_000_000, end_time_ms=2_000_000
+    )
+    assert grant_calls == [], "trackpoints endpoint must not call auth-grant"
+
+
+@pytest.mark.asyncio
+async def test_get_trip_trackpoints_normalises_8153(smart_fixture: respx.Router):
+    """Cloud ``code=8153`` ("data unavailable") → empty result, no raise."""
+
+    def _8153_response(_request):
+        return httpx.Response(
+            200,
+            json={"code": "8153", "message": "Connection interruption"},
+        )
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        for vin in ("TestVIN0000000001", "TestVIN0000000002"):
+            smart_fixture.get(re.compile(re.escape(
+                base + TRIP_TRACKPOINTS_PATH_PREFIX + vin
+            ) + r".*")).mock(side_effect=_8153_response)
+
+    account = await prepare_account_with_vehicles()
+    trackpoints = await account.get_trip_trackpoints(
+        "TestVIN0000000001", start_time_ms=1_000_000, end_time_ms=2_000_000
+    )
+    assert trackpoints == TripTrackpoints(points=[], total_size=0)
+
+
+@pytest.mark.asyncio
+async def test_get_trip_trackpoints_propagates_other_http_errors(smart_fixture: respx.Router):
+    """Non-8153 cloud errors propagate; only 8153 is normalised."""
+
+    def _500_response(_request):
+        return httpx.Response(
+            200,
+            json={"code": "5000", "message": "Internal server error"},
+        )
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        for vin in ("TestVIN0000000001", "TestVIN0000000002"):
+            smart_fixture.get(re.compile(re.escape(
+                base + TRIP_TRACKPOINTS_PATH_PREFIX + vin
+            ) + r".*")).mock(side_effect=_500_response)
+
+    account = await prepare_account_with_vehicles()
+    with pytest.raises(httpx.HTTPStatusError):
+        await account.get_trip_trackpoints(
+            "TestVIN0000000001", start_time_ms=1_000_000, end_time_ms=2_000_000
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_trip_trackpoints_warns_on_oversize_total(
+    smart_fixture: respx.Router, caplog: pytest.LogCaptureFixture
+):
+    """If cloud reports ``totleSize > pageSize``, log WARNING but still return head."""
+    big_total_body = {
+        "code": "1000",
+        "data": {
+            "pagination": {"totleSize": TRIP_TRACKPOINTS_PAGE_SIZE + 1, "pageSize": TRIP_TRACKPOINTS_PAGE_SIZE},
+            "list": [
+                {"basicVehicleStatus": {"position": {"latitude": 100, "longitude": 200}}}
+            ],
+        },
+    }
+
+    def _oversize_response(_request):
+        return httpx.Response(200, json=big_total_body)
+
+    for base in (API_BASE_URL, API_BASE_URL_V2):
+        for vin in ("TestVIN0000000001", "TestVIN0000000002"):
+            smart_fixture.get(re.compile(re.escape(
+                base + TRIP_TRACKPOINTS_PATH_PREFIX + vin
+            ) + r".*")).mock(side_effect=_oversize_response)
+
+    account = await prepare_account_with_vehicles()
+    with caplog.at_level(logging.WARNING, logger="pysmarthashtag.account"):
+        trackpoints = await account.get_trip_trackpoints(
+            "TestVIN0000000001", start_time_ms=1_000_000, end_time_ms=2_000_000
+        )
+    assert trackpoints.total_size == TRIP_TRACKPOINTS_PAGE_SIZE + 1
+    assert len(trackpoints.points) == 1
+    assert any(
+        "page-size cap exceeded" in record.message
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    )

--- a/pysmarthashtag/vehicle/trackpoints.py
+++ b/pysmarthashtag/vehicle/trackpoints.py
@@ -1,0 +1,131 @@
+"""Per-trip GPS trackpoint models for pysmarthashtag.
+
+The Smart cloud exposes a per-trip GPS trail at
+``/vehicle-history-service/journal-service/vehicle/status/history/{vin}``
+on the same ``apiv2.ecloudeu.com`` host as journalLogV4. The endpoint
+returns a list of ``{lat, lon}`` samples scaled in **milliarcseconds**
+(divide by 3,600,000 for WGS84 decimal degrees — same scaling as
+:class:`pysmarthashtag.vehicle.position.Position`).
+
+Unlike ``journalLogV4``, this endpoint does NOT require the
+``grant_journal_authorization`` per-session handshake — calling that
+defensively before every fetch would burn an extra cloud round-trip and
+risks transient ``7065`` errors on back-to-back grants.
+
+Cloud reports the list newest-first (``pagination.direction = "desc"``);
+:meth:`pysmarthashtag.account.SmartAccount.get_trip_trackpoints`
+reverses to chronological order before returning, so consumers don't
+need to know the wire format.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+# The cloud reports lat/lon as integer milliarcseconds. Convert to decimal
+# degrees with ``mas / 3_600_000`` — same scaling already used by
+# :class:`pysmarthashtag.vehicle.position.Position`.
+_MAS_PER_DEGREE = 3_600_000.0
+
+
+@dataclass(frozen=True)
+class Trackpoint:
+    """One GPS sample from a trip's recorded track.
+
+    The cloud's per-point payload is *only* lat/lon — no timestamp, no
+    SoC, no speed, no heading, no altitude. Both fields are nullable so a
+    degraded cloud entry whose ``position`` block is missing one or both
+    axes can still be recorded as a placeholder sample (sequence
+    integrity matters more than per-point completeness — one bad sample
+    shouldn't drop the rest of the trip).
+    """
+
+    lat: Optional[float] = None
+    """Latitude in decimal degrees (cloud reports milliarcseconds; we
+    divide by 3,600,000)."""
+
+    lon: Optional[float] = None
+    """Longitude in decimal degrees, same scaling as :attr:`lat`."""
+
+
+@dataclass(frozen=True)
+class TripTrackpoints:
+    """All GPS trackpoints for one trip, as returned by the history endpoint.
+
+    :attr:`points` is in *chronological* order — index 0 is the trip's
+    start sample, the last index is the end. The cloud transmits the
+    list reverse-chronologically (``pagination.direction = "desc"``);
+    :meth:`pysmarthashtag.account.SmartAccount.get_trip_trackpoints`
+    reverses at the wrapper boundary so callers don't need to know the
+    wire format.
+
+    :attr:`total_size` is the cloud's reported ``totleSize`` (sic — same
+    typo as journalLogV4). The default ``page_size=500`` matches the cap
+    the cloud advertises in its own ``pagination`` block; if a future
+    trip ever exceeds that, the wrapper logs a WARNING and the caller
+    still receives the truncated head.
+    """
+
+    points: list[Trackpoint]
+    """Trackpoints in chronological order (cloud sends desc; we reverse)."""
+
+    total_size: int = 0
+    """Cloud-reported total points for this trip (``data.pagination.totleSize``)."""
+
+
+def _trackpoint_from_cloud(item: Any) -> Trackpoint:
+    """Map one ``data.list`` entry to a :class:`Trackpoint`.
+
+    Defensive against degraded shapes: a missing ``basicVehicleStatus``
+    or ``position`` block, or an entry that isn't a dict at all, yields
+    ``Trackpoint(lat=None, lon=None)`` rather than raising.
+    """
+    if not isinstance(item, dict):
+        return Trackpoint()
+    basic = item.get("basicVehicleStatus") or {}
+    position = basic.get("position") if isinstance(basic, dict) else None
+    if not isinstance(position, dict):
+        return Trackpoint()
+    lat_mas = position.get("latitude")
+    lon_mas = position.get("longitude")
+    lat = lat_mas / _MAS_PER_DEGREE if isinstance(lat_mas, (int, float)) else None
+    lon = lon_mas / _MAS_PER_DEGREE if isinstance(lon_mas, (int, float)) else None
+    return Trackpoint(lat=lat, lon=lon)
+
+
+def parse_trackpoints_response(response_data: Any) -> TripTrackpoints:
+    """Build a :class:`TripTrackpoints` from a journal-service ``history`` body.
+
+    ``response_data`` is the full JSON dict returned by the endpoint
+    (``code`` / ``message`` / ``data``). Three benign-empty shapes all
+    map to ``TripTrackpoints(points=[], total_size=0)``:
+
+    * ``code: "1000"`` with ``data.list = []`` and ``totleSize: 0``
+      (cloud has no GPS trail for this trip)
+    * ``code: "1000"`` with ``data: null`` (alternate cloud-side empty)
+    * ``code: "8153"`` ("data unavailable" — propagates as
+      :class:`httpx.HTTPStatusError` from the SDK; the caller catches
+      it and falls back to this empty shape)
+
+    Cloud direction is ``desc`` (newest first); the returned
+    :attr:`TripTrackpoints.points` are reversed to chronological so
+    every consumer sees the same orientation.
+    """
+    if not isinstance(response_data, dict):
+        return TripTrackpoints(points=[], total_size=0)
+    data = response_data.get("data")
+    if not isinstance(data, dict):
+        return TripTrackpoints(points=[], total_size=0)
+    items_raw = data.get("list")
+    items = items_raw if isinstance(items_raw, list) else []
+    pagination = data.get("pagination") if isinstance(data.get("pagination"), dict) else {}
+    total_raw = pagination.get("totleSize") if isinstance(pagination, dict) else None
+    total_size = int(total_raw) if isinstance(total_raw, (int, float)) else len(items)
+
+    if not items:
+        return TripTrackpoints(points=[], total_size=total_size)
+
+    # Cloud sends ``direction: "desc"`` (newest-first). Reverse here so
+    # callers always see chronological samples — don't double-reverse
+    # downstream.
+    points = [_trackpoint_from_cloud(item) for item in reversed(items)]
+    return TripTrackpoints(points=points, total_size=total_size)


### PR DESCRIPTION
## Summary

Adds `account.get_trip_trackpoints(vin, start_time_ms, end_time_ms, page_size=500)` against `/vehicle-history-service/journal-service/vehicle/status/history/{VIN}` on `apiv2.ecloudeu.com`. A trip is identified by its `(start_time_ms, end_time_ms)` window (the endpoint has no trip-id). Returns `TripTrackpoints(points=[Trackpoint(lat, lon), ...], total_size)` in chronological order, with lat/lon as WGS84 decimal degrees.

Complements `get_trip_journal` from #194: that endpoint gives per-trip metrics plus the start/end positions embedded in `journalLogV4`; this one gives the GPS trail between them.

## What's added

- `pysmarthashtag/vehicle/trackpoints.py` — `Trackpoint` and `TripTrackpoints` frozen dataclasses, plus `parse_trackpoints_response`.
- `pysmarthashtag/account.py` — `get_trip_trackpoints`, module-level `TRIP_TRACKPOINTS_PATH_PREFIX`, `TRIP_TRACKPOINTS_PAGE_SIZE`, and a private `_is_benign_empty` helper.
- `pysmarthashtag/tests/test_trackpoints.py` (11 tests) and `pysmarthashtag/tests/replys/trackpoints_response.json` (4-point newest-first fixture).
- `pysmarthashtag/tests/common.py` — `SmartMockRouter` registers the trackpoints path prefix for both test VINs on each base URL.

## Design choices worth flagging

**No `grant_journal_authorization` ceremony.** Unlike `journalLogV4` from #194, this endpoint is not gated behind the per-session `authorization/insert` handshake. Calling grant defensively per fetch would add a cloud round-trip per trip and risks transient `7065` on back-to-back grants. We observed across sessions that the minimum flow is auth at startup (already done by `get_vehicles`) plus the single signed `GET`. `test_get_trip_trackpoints_does_not_call_grant` registers `authorization/insert` on both base URLs and asserts zero hits.

**`pageSize=500`, `pageIndex=0`, no page loop.** Page size is fixed at `TRIP_TRACKPOINTS_PAGE_SIZE = 500`, matching the cap the cloud advertises in its own `pagination` block. In observed responses `totleSize` never exceeded this. Rather than ship dead pagination code, the wrapper emits a `WARNING` ("page-size cap exceeded ... Wrapper does not loop pageIndex; returned points are the head only. Add pagination if this fires for real trips.") and still returns the truncated head. Locked by `test_get_trip_trackpoints_warns_on_oversize_total`. Caller can override `page_size`. Note: this endpoint is 0-indexed; `journalLogV4` is 1-indexed — empirical, not a typo.

**`desc` reversed to chronological at the wrapper boundary.** The cloud reports `pagination.direction = "desc"` (newest-first). `parse_trackpoints_response` reverses once via `reversed(items)` so every consumer sees `points[0]` = trip start, `points[-1]` = trip end. Tests `test_parse_reverses_to_chronological_order` and `test_get_trip_trackpoints_returns_chronological_points` lock this.

**Coordinate scaling — wire format, not Position-equivalence.** The cloud transmits lat/lon as integer milliarcseconds; `Trackpoint` exposes WGS84 decimal degrees (mas / 3,600,000 via `_MAS_PER_DEGREE`). The existing `pysmarthashtag.vehicle.position.Position` stores raw mas integers without conversion — `Trackpoint`'s decimal-degree convention is the more consumer-friendly representation for downstream consumers (e.g. HA trip-log integrations needing plottable WGS84). Happy to add a `Position.lat_degrees` property in a follow-up if preferred; docstring will be reworded to make the divergence explicit rather than claim equivalence.

**Defensive parsing.** Every nesting level (`response_data`, `data`, `data.list`, `data.pagination`, each `item`, `basicVehicleStatus`, `position`) is `isinstance`-guarded. Degraded entries yield `Trackpoint(lat=None, lon=None)` placeholders rather than dropping out — sequence integrity over per-point completeness. `total_size` falls back to `len(items)` when `totleSize` is missing or non-numeric.

**Three benign-empty paths collapse to `TripTrackpoints(points=[], total_size=0)`:** `code "1000"` + empty list, `code "1000"` + `data: null`, and `code "8153"` "data unavailable". The 8153 case arrives as `httpx.HTTPStatusError` from the lower layer; `_is_benign_empty` JSON-decodes the response body and matches on `code == "8153"`. All other `HTTPStatusError`s re-raise — locked by `test_get_trip_trackpoints_normalises_8153` and `test_get_trip_trackpoints_propagates_other_http_errors` (uses `code: "5000"`).

**No refresh-path coupling.** `get_trip_trackpoints` is caller opt-in; it is not invoked from `_refresh_vehicle_data`. Adding this endpoint cannot make periodic refresh more fragile.

## Tests

Parser-only: `test_parse_handles_none_and_non_dict`, `test_parse_handles_empty_data_block`, `test_parse_handles_empty_list_with_zero_total`, `test_parse_reverses_to_chronological_order`, `test_parse_milliarcsecond_to_degree_scaling`, `test_parse_handles_degraded_per_point_payload`, `test_parse_non_list_payload_coerces_to_empty`.

End-to-end (`respx`): `test_get_trip_trackpoints_returns_chronological_points`, `test_get_trip_trackpoints_does_not_call_grant`, `test_get_trip_trackpoints_normalises_8153`, `test_get_trip_trackpoints_propagates_other_http_errors`, `test_get_trip_trackpoints_warns_on_oversize_total`.

Signing reuses the existing `utils.generate_default_header` HMAC path — no changes to auth or request signing.