### PR TITLE
fix(auth): recover cleanly from a failed API-session exchange

### DIFF
--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -165,6 +165,22 @@ class SmartAccount:
             self.config.authentication = None
         await self.config.authentication.login()
 
+    def invalidate_session(self) -> None:
+        """Force the next data poll to perform a full re-login.
+
+        Clears the cached API identity on the authentication handler so
+        :meth:`get_vehicles` (which only re-logins when ``api_user_id is
+        None``) re-enters the complete login journey instead of replaying a
+        stale token. Provided for callers (e.g. the Home Assistant
+        coordinator) that observe repeated data-endpoint failures — such as
+        ``4038``/``8040`` — which never trip the token-refresh path and so
+        would otherwise wedge the session until a full reload. Safe to call
+        when no session exists.
+        """
+        auth = getattr(self.config, "authentication", None)
+        if auth is not None:
+            auth._invalidate_session()
+
     async def _init_vehicles(self) -> None:
         """Initialize vehicles from Smart servers."""
         _LOGGER.debug("Getting initial vehicle list")

--- a/pysmarthashtag/api/authentication.py
+++ b/pysmarthashtag/api/authentication.py
@@ -170,14 +170,40 @@ class SmartAuthentication(httpx.Auth):
             )
             raise
 
+    def _invalidate_session(self) -> None:
+        """Drop all cached session identity so the next login starts fresh.
+
+        A half-completed login must not leave a stale ``api_user_id`` /
+        ``api_access_token`` behind: ``SmartAccount.get_vehicles()`` only
+        forces a fresh ``login()`` when ``api_user_id is None``, so a
+        lingering value makes it replay a dead token every poll (the cloud
+        answers 1402/4038/8040) and the session never self-heals — only a
+        full integration reload recovers it. Clearing the identity here lets
+        the next poll re-enter the complete login journey.
+        """
+        self.access_token = None
+        self.refresh_token = None
+        self.api_access_token = None
+        self.api_refresh_token = None
+        self.api_user_id = None
+        self.expires_at = None
+
     async def login(self) -> None:
         """Login to the Smart API."""
         _LOGGER.debug("Logging in to Smart API")
         token_data = {}
-        if self.refresh_token:
-            token_data = await self._refresh_access_token()
-        if not token_data:
-            token_data = await self._login()
+        try:
+            if self.refresh_token:
+                token_data = await self._refresh_access_token()
+            if not token_data:
+                token_data = await self._login()
+        except Exception:
+            # Any failure in the login journey (rate-limit, WAF, failed
+            # session exchange, ...) must invalidate whatever partial state
+            # we hold so the next attempt starts clean rather than replaying
+            # a stale token. The exception still propagates to the caller.
+            self._invalidate_session()
+            raise
         try:
             token_data["expires_at"] = token_data["expires_at"] - EXPIRES_AT_OFFSET
 
@@ -189,16 +215,25 @@ class SmartAuthentication(httpx.Auth):
             self.expires_at = token_data["expires_at"]
             _LOGGER.debug("Login successful")
             return True
-        except KeyError:
-            raise SmartAPIError("Could not login to Smart API")
+        except (KeyError, TypeError) as err:
+            self._invalidate_session()
+            raise SmartAPIError("Could not login to Smart API") from err
 
     async def _refresh_access_token(self):
-        """Refresh the access token."""
+        """Refresh the access token.
+
+        The refresh-token grant is not implemented server-side, so this
+        performs a full re-login and RETURNS its token data. Returning the
+        result (rather than discarding it) is essential: ``login()`` falls
+        back to a second ``_login()`` whenever this returns falsy, so
+        discarding the data caused two full login flows per refresh —
+        doubling auth pressure against the rate-limited Smart gateway.
+        """
         try:
             ssl_ctx = await self.get_ssl_context()
             async with SmartLoginClient(ssl_context=ssl_ctx) as _:
                 _LOGGER.debug("Refreshing access token via relogin because refresh token is not implemented")
-                await self._login()
+                return await self._login()
         except SmartAPIError:
             _LOGGER.debug("Refreshing access token failed. Logging in again")
             return {}
@@ -273,6 +308,13 @@ class SmartAuthentication(httpx.Auth):
             or "http 403" in text
             or "http 429" in text
             or "forbidden" in text
+            # Throttle wording the cloud may return as an HTTP-200 error body
+            # (surfaced into the exception text by _do_login's session-exchange
+            # handler). Kept deliberately narrow so genuine one-off failures
+            # (e.g. "Could not get access token from auth page") are unaffected.
+            or "too many" in text
+            or "throttl" in text
+            or "try again later" in text
         )
 
     async def _do_login(self) -> dict:
@@ -552,8 +594,29 @@ class SmartAuthentication(httpx.Auth):
                 api_access_token = api_result["data"]["accessToken"]
                 api_refresh_token = api_result["data"]["refreshToken"]
                 api_user_id = api_result["data"]["userId"]
-            except KeyError:
-                raise SmartAPIError("Could not get API access token from API")
+            except (KeyError, TypeError) as err:
+                # The OAuth flow succeeded but the final API-session exchange
+                # did not return a session. Surface the cloud's own code +
+                # message (mirrors the Gigya-login step above) instead of a
+                # fixed generic string. Two reasons this matters:
+                #   * diagnosability — the log now says *why* it failed;
+                #   * classification — _is_rate_limit_error() can only see the
+                #     exception text, so a throttle/WAF block hidden here would
+                #     otherwise be mistaken for a transient blip and get the
+                #     short 60s suppress instead of the geometric backoff.
+                api_code = api_result.get("code") if isinstance(api_result, dict) else None
+                api_message = api_result.get("message", "") if isinstance(api_result, dict) else ""
+                http_status = r_api_access.status_code
+                _LOGGER.error(
+                    "API session exchange failed (HTTP %s, code=%s): %s",
+                    http_status,
+                    api_code,
+                    sanitize_log_data(api_message),
+                )
+                raise SmartAPIError(
+                    "Could not get API access token from API "
+                    f"(HTTP {http_status}, code={api_code}): {api_message}"
+                ) from err
 
         return {
             "access_token": access_token,

--- a/pysmarthashtag/tests/test_authentication_backoff.py
+++ b/pysmarthashtag/tests/test_authentication_backoff.py
@@ -191,3 +191,97 @@ class TestAdaptiveBackoff:
                 await a2._login()
 
         assert calls["n"] == 0, "shared quiet window did not suppress second instance"
+
+
+class TestSessionRecovery:
+    """Regression tests for login-failure recovery (fix/login-session-recovery).
+
+    Covers the four defects that let a failed API-session exchange wedge the
+    account until a full integration reload:
+
+    * the session-exchange error is surfaced (code/message + HTTP status),
+    * a failed login invalidates cached identity so the next poll re-logins,
+    * ``_refresh_access_token`` returns its result (no double full login),
+    * throttle wording is classified as a rate-limit failure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_login_failure_invalidates_session(self):
+        """A failed login must clear api_user_id so get_vehicles re-logins."""
+        auth = _make_auth()
+        # Simulate a previously-good session left over from an earlier login.
+        auth.api_user_id = "stale-user"
+        auth.api_access_token = "stale-token"
+        auth.access_token = "stale-oauth"
+
+        async def boom():
+            raise SmartAPIError("Could not get API access token from API (HTTP 200, code=1402): token expired")
+
+        with patch.object(auth, "_do_login", boom):
+            auth._state.quiet_until = None
+            with pytest.raises(SmartAPIError):
+                await auth.login()
+
+        # Stale identity must be gone so SmartAccount.get_vehicles() (which
+        # only re-logins when api_user_id is None) restarts the journey.
+        assert auth.api_user_id is None
+        assert auth.api_access_token is None
+        assert auth.access_token is None
+
+    @pytest.mark.asyncio
+    async def test_successful_login_sets_session(self):
+        """A clean login still populates identity (invalidation is failure-only)."""
+        auth = _make_auth()
+
+        async def ok():
+            return _login_stub()
+
+        with patch.object(auth, "_do_login", ok):
+            auth._state.quiet_until = None
+            await auth.login()
+        assert auth.api_user_id == "z"
+        assert auth.api_access_token == "x"
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_result_no_double_login(self):
+        """With a refresh_token set, login() must not run _login() twice."""
+        auth = _make_auth()
+        auth.refresh_token = "prior-refresh"
+        calls = {"n": 0}
+
+        async def counting_login():
+            calls["n"] += 1
+            return _login_stub()
+
+        with patch.object(auth, "_login", counting_login):
+            await auth.login()
+
+        assert calls["n"] == 1, "login ran the full flow twice on refresh"
+        assert auth.api_user_id == "z"
+
+    def test_throttle_wording_is_rate_limit(self):
+        """HTTP-200 throttle bodies surfaced into the message classify as rate-limit."""
+        assert SmartAuthentication._is_rate_limit_error(
+            SmartAPIError("Could not get API access token from API (HTTP 429, code=...): x")
+        )
+        assert SmartAuthentication._is_rate_limit_error(
+            SmartAPIError("request throttled, try again later")
+        )
+        assert SmartAuthentication._is_rate_limit_error(SmartAPIError("Too Many Requests"))
+        # A genuine one-off failure must NOT be misread as a rate-limit.
+        assert not SmartAuthentication._is_rate_limit_error(
+            SmartAPIError("Could not get access token from auth page")
+        )
+
+
+def _login_stub() -> dict:
+    """Minimal successful token payload for login() (mirrors _login_ok)."""
+    return {
+        "access_token": "a",
+        "refresh_token": "r",
+        "api_access_token": "x",
+        "api_refresh_token": "y",
+        "api_user_id": "z",
+        "expires_at": datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+    }

--- a/pysmarthashtag/tests/test_authentication_backoff.py
+++ b/pysmarthashtag/tests/test_authentication_backoff.py
@@ -234,7 +234,7 @@ class TestSessionRecovery:
         auth = _make_auth()
 
         async def ok():
-            return _login_stub()
+            return _login_ok()
 
         with patch.object(auth, "_do_login", ok):
             auth._state.quiet_until = None
@@ -251,7 +251,7 @@ class TestSessionRecovery:
 
         async def counting_login():
             calls["n"] += 1
-            return _login_stub()
+            return _login_ok()
 
         with patch.object(auth, "_login", counting_login):
             await auth.login()
@@ -272,16 +272,3 @@ class TestSessionRecovery:
         assert not SmartAuthentication._is_rate_limit_error(
             SmartAPIError("Could not get access token from auth page")
         )
-
-
-def _login_stub() -> dict:
-    """Minimal successful token payload for login() (mirrors _login_ok)."""
-    return {
-        "access_token": "a",
-        "refresh_token": "r",
-        "api_access_token": "x",
-        "api_refresh_token": "y",
-        "api_user_id": "z",
-        "expires_at": datetime.datetime.now(datetime.timezone.utc)
-        + datetime.timedelta(hours=1),
-    }


### PR DESCRIPTION
## Summary

edit: changed this PR to draft while I work instead on Token Refresh which hopefully replaces this one.

Fixes the integration getting stuck with **all sensors `unavailable`** —
recoverable only by a full reload — after a failed login / API-session exchange.

I share the fix I am testing in my home assistant. I am thinking of calling it a success if I don't get stuck in unavailable state for a full week. (next Sunday)

## Problem

The EU login is a multi-step OAuth + Gigya flow. The OAuth steps can succeed
while the **final API-session exchange** (`/auth/account/session/secure`) returns
an error body. When that happens today:

- `_do_login()` raises a fixed generic
  `SmartAPIError("Could not get API access token from API")` and discards the
  cloud's actual `code`/`message`. Since the adaptive backoff classifier
  (`_is_rate_limit_error`) can only see the exception text, a throttle/WAF block
  hidden here is misread as a transient blip and gets the short 60s suppress
  instead of the geometric backoff — so it keeps hammering.
- `_refresh_access_token()` runs a full `_login()` but **discards the result**,
  so `login()` falls through and runs `_login()` a second time — two full login
  flows per refresh, doubling pressure on the rate-limited gateway.
- On failure, `login()` never clears `api_user_id`. Because
  `SmartAccount.get_vehicles()` only forces a fresh `login()` when
  `api_user_id is None`, a stale value makes it **replay a dead token** every
  poll (the cloud answers 1402/4038/8040) and the session never self-heals —
  only recreating the account (an integration reload) recovers it.

Net effect for the Home Assistant integration: a transient cloud/login hiccup can
wedge the whole integration into `unavailable` until the user manually reloads.

## Changes

All in `pysmarthashtag/api/authentication.py`, plus one public helper in
`account.py`:

- **Surface the session-exchange error** — include the HTTP status and the
  cloud's `code`/`message` in the raised `SmartAPIError` (mirrors the existing
  Gigya-login error handling), so logs show the real cause.
- **Classify rate-limits correctly** — the surfaced status/wording now trips the
  geometric AIMD backoff instead of the fixed 60s "other failure" path; added a
  few throttle-wording tokens to `_is_rate_limit_error`.
- **No double login on refresh** — `_refresh_access_token()` returns its
  `_login()` result so `login()` doesn't run the flow twice.
- **Invalidate session on any login failure** — new `_invalidate_session()`
  clears `access_token`/`refresh_token`/`api_*`/`expires_at`; `login()` calls it
  on failure so the next poll re-enters the full login journey instead of
  replaying a stale token.
- **`SmartAccount.invalidate_session()`** — a small public helper so a caller
  (e.g. the Home Assistant coordinator) can force a clean re-login after repeated
  data-endpoint failures (`4038`/`8040`) that never trip the token-refresh path.

No breaking changes — additions and internal behavior only; existing signatures
and return values are unchanged.

## Testing

- New `TestSessionRecovery` covering: invalidate-on-failure, successful login
  still populates identity, no double login on refresh, and throttle-wording
  classification.
- Full suite passes (150 tests).
- Also verified running live on Home Assistant OS.

## Companion change

A matching PR to the integration (DasBasti/SmartHashtag#447) calls
`SmartAccount.invalidate_session()` once the coordinator crosses its
consecutive-failure ceiling, guarded with `hasattr` for older library releases —
defense-in-depth for the `4038`/`8040` data-endpoint case that never reaches the
token-refresh path.

## Trying this branch on Home Assistant (before a release)

The integration pins a fixed `pysmarthashtag` version, so to run this branch you
build a wheel and point the integration's manifest at it. No SSH-into-the-
container needed: HA **reinstalls any URL requirement on every start**
(`homeassistant/util/package.py::is_installed()` returns `False` for
`@`-reference requirements).

1. **Build a wheel from this branch** (Python 3 with
   `pip`/`setuptools`/`setuptools-scm`; output is pure `py3-none-any`):
   ```bash
   git clone -b fix/login-session-recovery https://github.com/chriscatuk/pySmartHashtag
   cd pySmartHashtag
   SETUPTOOLS_SCM_PRETEND_VERSION=0.10.2 python -m pip wheel --no-deps -w dist .
   # -> dist/pysmarthashtag-0.10.2-py3-none-any.whl
   ```
   (The forced `0.10.2` just gives a clean filename that pip treats as newer
   than the pinned version.)
2. **Copy the wheel into your HA config folder** (Samba / SSH / File editor),
   e.g. to `/config/`.
3. **Point the integration at it** — edit
   `/config/custom_components/smarthashtag/manifest.json`:
   ```json
   "requirements": ["pysmarthashtag @ file:///config/pysmarthashtag-0.10.2-py3-none-any.whl"],
   ```
4. **Restart Home Assistant.** On boot HA installs the wheel over the pinned
   version.
5. **To revert:** set the requirement back to the normal pin
   (e.g. `"pysmarthashtag==0.10.1"`) and restart.

Notes:
- The library deps (`httpx`, `pycryptodome`, `pyjwt`) are already present, so the
  install needs no internet.
- HA Core / venv installs work the same way; only the path to `/config` differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
