### PR TITLE
feat(auth): layered token/session lifecycle (refresh + re-bind, no relogin storms)

### DIFF
--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -234,40 +234,67 @@ class SmartAccount:
         if len(self.vehicles) == 0 or force_init:
             await self._init_vehicles()
 
+        errors: list[Exception] = []
+        succeeded = 0
         for vin, vehicle in self.vehicles.items():
             _LOGGER.debug("Getting vehicle data")
-            await self.select_active_vehicle(vin)
-            vehicle_info = await self.get_vehicle_information(vin)
-            vehicle_soc = await self.get_vehicle_soc(vin)
-            vehicle_ota_info = await self.get_vehicle_ota_info(vin)
-            # Trip journal is best-effort: the endpoint can return 8153
-            # ("data unavailable") on vehicles where on-vehicle trip
-            # recording is OFF, or transiently when the per-session auth
-            # grant hasn't been accepted yet. Never let an empty journal
-            # fail the whole refresh.
-            journal_response = None
             try:
-                journal_response = await self.get_trip_journal(vin)
-            except Exception:  # noqa: BLE001  # Best-effort: any failure (8153, transport, parse) must not break refresh.
-                _LOGGER.debug(
-                    "Trip journal fetch failed for %s", sanitize_log_data(vin), exc_info=True
+                await self.select_active_vehicle(vin)
+                vehicle_info = await self.get_vehicle_information(vin)
+                vehicle_soc = await self.get_vehicle_soc(vin)
+                # OTA info is best-effort: the OTA service (ota.srv.smart.com) can
+                # return HTTP 500 for some VINs (e.g. shared cars, or transiently).
+                # It is not core telemetry, so it must never fail the whole refresh
+                # and drop every sensor to `unavailable`.
+                vehicle_ota_info = None
+                try:
+                    vehicle_ota_info = await self.get_vehicle_ota_info(vin)
+                except Exception:  # noqa: BLE001  # Best-effort: OTA failure must not break refresh.
+                    _LOGGER.debug(
+                        "OTA info fetch failed for %s", sanitize_log_data(vin), exc_info=True
+                    )
+                # Trip journal is best-effort: the endpoint can return 8153
+                # ("data unavailable") on vehicles where on-vehicle trip
+                # recording is OFF, or transiently when the per-session auth
+                # grant hasn't been accepted yet. Never let an empty journal
+                # fail the whole refresh.
+                journal_response = None
+                try:
+                    journal_response = await self.get_trip_journal(vin)
+                except Exception:  # noqa: BLE001  # Best-effort: any failure (8153, transport, parse) must not break refresh.
+                    _LOGGER.debug(
+                        "Trip journal fetch failed for %s", sanitize_log_data(vin), exc_info=True
+                    )
+                # Per-VIN TBox state flags (engine/journal/valet/etc.) — best-effort,
+                # same reasoning as the journal call above.
+                state_response = None
+                try:
+                    state_response = await self.get_vehicle_state(vin)
+                except Exception:  # noqa: BLE001  # Best-effort: state fetch must not break refresh.
+                    _LOGGER.debug(
+                        "Vehicle-state fetch failed for %s", sanitize_log_data(vin), exc_info=True
+                    )
+                vehicle.combine_data(
+                    vehicle_info,
+                    charging_settings=vehicle_soc,
+                    ota_info=vehicle_ota_info,
+                    journal_response=journal_response,
+                    state_response=state_response,
                 )
-            # Per-VIN TBox state flags (engine/journal/valet/etc.) — best-effort,
-            # same reasoning as the journal call above.
-            state_response = None
-            try:
-                state_response = await self.get_vehicle_state(vin)
-            except Exception:  # noqa: BLE001  # Best-effort: state fetch must not break refresh.
-                _LOGGER.debug(
-                    "Vehicle-state fetch failed for %s", sanitize_log_data(vin), exc_info=True
+                succeeded += 1
+            except Exception as exc:  # noqa: BLE001
+                # Per-car isolation: one flaky vehicle (often a shared car with a
+                # failing endpoint) must not drop every sensor of the others.
+                errors.append(exc)
+                _LOGGER.warning(
+                    "Vehicle %s update failed this cycle: %s",
+                    sanitize_log_data(vin),
+                    exc,
                 )
-            vehicle.combine_data(
-                vehicle_info,
-                charging_settings=vehicle_soc,
-                ota_info=vehicle_ota_info,
-                journal_response=journal_response,
-                state_response=state_response,
-            )
+        # Surface a real error only if NO vehicle updated — otherwise the
+        # coordinator would mark a total failure when just one car is flaky.
+        if succeeded == 0 and errors:
+            raise errors[0]
 
     async def select_active_vehicle(self, vin) -> None:
         """Select the active vehicle."""

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -19,6 +19,7 @@ from pysmarthashtag.models import (
     SmartAuthError,
     SmartHumanCarConnectionError,
     SmartTokenRefreshNecessary,
+    SmartVehicleNotInUseError,
 )
 from pysmarthashtag.vehicle.trackpoints import TripTrackpoints, parse_trackpoints_response
 from pysmarthashtag.vehicle.vehicle import SmartVehicle
@@ -194,7 +195,8 @@ class SmartAccount:
                     )
                     _LOGGER.debug("Got response %d", vehicles_response.status_code)
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
                 except SmartHumanCarConnectionError:
                     _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
@@ -209,6 +211,17 @@ class SmartAccount:
     def add_vehicle(self, vehicle, fetched_at):
         """Add a vehicle to the account."""
         self.vehicles[vehicle.get("vin")] = SmartVehicle(self, vehicle, fetched_at=fetched_at)
+
+    def _vin_model_code(self, vin) -> Optional[str]:
+        """Return the VIN's ``matCode`` for the ``X-VEHICLE-*`` headers.
+
+        ``None`` if the vehicle (or its model code) isn't known yet — the
+        header generator then simply omits the per-request VIN headers.
+        """
+        vehicle = self.vehicles.get(vin)
+        if vehicle is None:
+            return None
+        return vehicle.data.get("matCode")
 
     async def get_vehicles(self, force_init: bool = False) -> None:
         """Get the vehicles associated with the account."""
@@ -285,11 +298,15 @@ class SmartAccount:
                     )
                     _LOGGER.debug("Got response %d", r_car_info.status_code)
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
-                except SmartHumanCarConnectionError:
-                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
-                    self.select_active_vehicle(vin)
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                    # This method IS the re-bind — just retry the select request
+                    # (the loop re-attempts it). Calling select_active_vehicle()
+                    # here would recurse and could hit RecursionError on
+                    # persistent 8006/4038.
+                    _LOGGER.debug("VIN binding lost (8006/4038) while selecting; retrying (retry %d)", retry)
                     continue
                 break
 
@@ -318,6 +335,8 @@ class SmartAccount:
                                 params=params,
                                 method="GET",
                                 url="/remote-control/vehicle/status/" + vin,
+                                vin=vin,
+                                model_code=self._vin_model_code(vin),
                             )
                         },
                     )
@@ -325,10 +344,11 @@ class SmartAccount:
                     self.vehicles.get(vin).combine_data(r_car_info.json()["data"])
                     data = r_car_info.json()["data"]
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
-                except SmartHumanCarConnectionError:
-                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                    _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
                     continue
                 break
@@ -362,16 +382,19 @@ class SmartAccount:
                                 params={},
                                 method="GET",
                                 url=path,
+                                vin=vin,
+                                model_code=self._vin_model_code(vin),
                             )
                         },
                     )
                     _LOGGER.debug("Got response %d", r_state.status_code)
                     data = r_state.json()
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
-                except SmartHumanCarConnectionError:
-                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                    _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
                     continue
                 break
@@ -400,6 +423,8 @@ class SmartAccount:
                                 params=params,
                                 method="GET",
                                 url="/remote-control/vehicle/status/soc/" + vin,
+                                vin=vin,
+                                model_code=self._vin_model_code(vin),
                             )
                         },
                     )
@@ -407,11 +432,12 @@ class SmartAccount:
                     self.vehicles.get(vin).combine_data(r_car_info.json()["data"])
                     data = r_car_info.json()["data"]
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
-                except SmartHumanCarConnectionError:
-                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
-                    self.select_active_vehicle(vin)
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                    _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
+                    await self.select_active_vehicle(vin)
                     continue
                 break
             if retry > 1:
@@ -672,16 +698,19 @@ class SmartAccount:
                                 params=params,
                                 method="GET",
                                 url=path,
+                                vin=vin,
+                                model_code=self._vin_model_code(vin),
                             )
                         },
                     )
                     _LOGGER.debug("Got response %d", response.status_code)
                     data = response.json()
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
-                except SmartHumanCarConnectionError:
-                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                    _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
                     continue
                 break
@@ -751,16 +780,19 @@ class SmartAccount:
                                 params=params,
                                 method="GET",
                                 url=path,
+                                vin=vin,
+                                model_code=self._vin_model_code(vin),
                             )
                         },
                     )
                     _LOGGER.debug("Got response %d", response.status_code)
                     body = response.json()
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
-                except SmartHumanCarConnectionError:
-                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                    _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
                     continue
                 except httpx.HTTPStatusError as exc:
@@ -813,11 +845,12 @@ class SmartAccount:
                         "current_version": json_data.get("currentVersion"),
                     }
                 except SmartTokenRefreshNecessary:
-                    _LOGGER.debug("Got Token Error, retry: %d", retry)
+                    _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
+                    await self.config.authentication.refresh()
                     continue
-                except SmartHumanCarConnectionError:
-                    _LOGGER.debug("Got Human Car Connection Error, retry: %d", retry)
-                    self.select_active_vehicle(vin)
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                    _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
+                    await self.select_active_vehicle(vin)
                     continue
                 break
             if retry > 1:

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -125,9 +125,7 @@ class SmartAccount:
 
     tracked_vins: Optional[list[str]] = None
     """Optional. If set, only these VIN(s) are fetched and tracked; any other
-    vehicle on the account (e.g. a shared car that appears after switching
-    cars in the phone app) is ignored — no polling, no entities. ``None``
-    tracks every vehicle on the account (previous behaviour)."""
+    vehicle on the account is ignored. ``None`` tracks all (previous behaviour)."""
 
     vehicles: dict[str, SmartVehicle] = field(default_factory=dict, init=False)
     """Vehicles associated with the account."""
@@ -225,7 +223,7 @@ class SmartAccount:
     def _vin_model_code(self, vin) -> Optional[str]:
         """Return the VIN's ``matCode`` for the ``X-VEHICLE-*`` headers.
 
-        ``None`` if the vehicle (or its model code) isn't known yet — the
+        ``None`` if the vehicle (or its model code) isn't known yet, so the
         header generator then simply omits the per-request VIN headers.
         """
         vehicle = self.vehicles.get(vin)
@@ -252,10 +250,7 @@ class SmartAccount:
                 await self.select_active_vehicle(vin)
                 vehicle_info = await self.get_vehicle_information(vin)
                 vehicle_soc = await self.get_vehicle_soc(vin)
-                # OTA info is best-effort: the OTA service (ota.srv.smart.com) can
-                # return HTTP 500 for some VINs (e.g. shared cars, or transiently).
-                # It is not core telemetry, so it must never fail the whole refresh
-                # and drop every sensor to `unavailable`.
+                # Best-effort: the OTA service can return HTTP 500.
                 vehicle_ota_info = None
                 try:
                     vehicle_ota_info = await self.get_vehicle_ota_info(vin)
@@ -275,7 +270,7 @@ class SmartAccount:
                     _LOGGER.debug(
                         "Trip journal fetch failed for %s", sanitize_log_data(vin), exc_info=True
                     )
-                # Per-VIN TBox state flags (engine/journal/valet/etc.) — best-effort,
+                # Per-VIN TBox state flags (engine/journal/valet/etc.), best-effort,
                 # same reasoning as the journal call above.
                 state_response = None
                 try:
@@ -301,7 +296,7 @@ class SmartAccount:
                     sanitize_log_data(vin),
                     exc,
                 )
-        # Surface a real error only if NO vehicle updated — otherwise the
+        # Surface a real error only if NO vehicle updated, otherwise the
         # coordinator would mark a total failure when just one car is flaky.
         if succeeded == 0 and errors:
             raise errors[0]
@@ -339,7 +334,7 @@ class SmartAccount:
                     await self.config.authentication.refresh()
                     continue
                 except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
-                    # This method IS the re-bind — just retry the select request
+                    # This method IS the re-bind, so just retry the select request
                     # (the loop re-attempts it). Calling select_active_vehicle()
                     # here would recurse and could hit RecursionError on
                     # persistent 8006/4038.
@@ -389,7 +384,8 @@ class SmartAccount:
                     await self.select_active_vehicle(vin)
                     continue
                 break
-            if retry > 1:
+            else:
+                # Only when every attempt failed; the loop breaks on success.
                 raise SmartAuthError("Could not get vehicle information")
         return data
 
@@ -477,7 +473,8 @@ class SmartAccount:
                     await self.select_active_vehicle(vin)
                     continue
                 break
-            if retry > 1:
+            else:
+                # Only when every attempt failed; the loop breaks on success.
                 raise SmartAuthError("Could not get vehicle information")
         return data
 
@@ -890,6 +887,7 @@ class SmartAccount:
                     await self.select_active_vehicle(vin)
                     continue
                 break
-            if retry > 1:
+            else:
+                # Only when every attempt failed; the loop breaks on success.
                 raise SmartAuthError("Could not get vehicle information")
         return data

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -53,6 +53,23 @@ _BENIGN_EMPTY_CODE = "8153"
 _LOGGER = logging.getLogger(__name__)
 
 
+def _cloud_code(exc: httpx.HTTPStatusError) -> Optional[str]:
+    """Return the cloud response code carried by ``exc``, if it has one.
+
+    ``None`` means the failure came from the transport or the HTTP status
+    rather than a cloud error body, so no token remedy applies to it.
+    """
+    response = exc.response
+    if response is None:
+        return None
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    code = body.get("code")
+    return None if code is None else str(code)
+
+
 def _is_benign_empty(exc: httpx.HTTPStatusError) -> bool:
     """Return True iff ``exc`` carries the cloud's 8153 "data unavailable" code.
 
@@ -61,14 +78,7 @@ def _is_benign_empty(exc: httpx.HTTPStatusError) -> bool:
     end-of-data signal for journal endpoints — callers normalise it to
     an empty result rather than propagating it as an error.
     """
-    response = exc.response
-    if response is None:
-        return False
-    try:
-        body = response.json()
-    except ValueError:
-        return False
-    return str(body.get("code")) == _BENIGN_EMPTY_CODE
+    return _cloud_code(exc) == _BENIGN_EMPTY_CODE
 
 
 def _unwrap_journal_page(body: dict) -> tuple[list, Optional[int]]:
@@ -353,6 +363,7 @@ class SmartAccount:
         data = {}
         async with SmartClient(self.config) as client:
             last_error = None
+            refreshed_unmapped = False
             for retry in range(3):
                 try:
                     r_car_info = await client.get(
@@ -385,6 +396,16 @@ class SmartAccount:
                     last_error = exc
                     _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
+                    continue
+                except httpx.HTTPStatusError as exc:
+                    # Unmapped code: one refresh in case the session is stale, then surface.
+                    code = _cloud_code(exc)
+                    if code is None or refreshed_unmapped:
+                        raise
+                    refreshed_unmapped = True
+                    last_error = exc
+                    _LOGGER.warning("Unmapped cloud code %s; refreshing session once", code)
+                    await self.config.authentication.refresh()
                     continue
                 break
             else:
@@ -446,6 +467,7 @@ class SmartAccount:
         data = {}
         async with SmartClient(self.config) as client:
             last_error = None
+            refreshed_unmapped = False
             for retry in range(3):
                 try:
                     r_car_info = await client.get(
@@ -478,6 +500,16 @@ class SmartAccount:
                     last_error = exc
                     _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
+                    continue
+                except httpx.HTTPStatusError as exc:
+                    # Unmapped code: one refresh in case the session is stale, then surface.
+                    code = _cloud_code(exc)
+                    if code is None or refreshed_unmapped:
+                        raise
+                    refreshed_unmapped = True
+                    last_error = exc
+                    _LOGGER.warning("Unmapped cloud code %s; refreshing session once", code)
+                    await self.config.authentication.refresh()
                     continue
                 break
             else:
@@ -864,6 +896,7 @@ class SmartAccount:
         data = {}
         async with SmartClient(self.config) as client:
             last_error = None
+            refreshed_unmapped = False
             for retry in range(3):
                 try:
                     r_car_info = await client.get(
@@ -896,6 +929,16 @@ class SmartAccount:
                     last_error = exc
                     _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
+                    continue
+                except httpx.HTTPStatusError as exc:
+                    # Unmapped code: one refresh in case the session is stale, then surface.
+                    code = _cloud_code(exc)
+                    if code is None or refreshed_unmapped:
+                        raise
+                    refreshed_unmapped = True
+                    last_error = exc
+                    _LOGGER.warning("Unmapped cloud code %s; refreshing session once", code)
+                    await self.config.authentication.refresh()
                     continue
                 break
             else:

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -265,7 +265,8 @@ class SmartAccount:
                 journal_response = None
                 try:
                     journal_response = await self.get_trip_journal(vin)
-                except Exception:  # noqa: BLE001  # Best-effort: any failure (8153, transport, parse) must not break refresh.
+                except Exception:  # noqa: BLE001
+                    # Best-effort: any failure (8153, transport, parse) must not break refresh.
                     _LOGGER.debug(
                         "Trip journal fetch failed for %s", sanitize_log_data(vin), exc_info=True
                     )
@@ -293,7 +294,7 @@ class SmartAccount:
                 _LOGGER.warning(
                     "Vehicle %s update failed this cycle: %s",
                     sanitize_log_data(vin),
-                    exc,
+                    sanitize_log_data(str(exc)),
                 )
         # Surface a real error only if NO vehicle updated, otherwise the
         # coordinator would mark a total failure when just one car is flaky.

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -16,7 +16,6 @@ from pysmarthashtag.api.log_sanitizer import sanitize_log_data
 from pysmarthashtag.const import API_CARS_URL, API_SELECT_CAR_URL, EndpointUrls
 from pysmarthashtag.models import (
     JournalTruncationError,
-    SmartAuthError,
     SmartHumanCarConnectionError,
     SmartTokenRefreshNecessary,
     SmartVehicleNotInUseError,
@@ -352,6 +351,7 @@ class SmartAccount:
         }
         data = {}
         async with SmartClient(self.config) as client:
+            last_error = None
             for retry in range(3):
                 try:
                     r_car_info = await client.get(
@@ -375,18 +375,21 @@ class SmartAccount:
                     _LOGGER.debug("Got response %d", r_car_info.status_code)
                     self.vehicles.get(vin).combine_data(r_car_info.json()["data"])
                     data = r_car_info.json()["data"]
-                except SmartTokenRefreshNecessary:
+                except SmartTokenRefreshNecessary as exc:
+                    last_error = exc
                     _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
                     await self.config.authentication.refresh()
                     continue
-                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError) as exc:
+                    last_error = exc
                     _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
                     continue
                 break
             else:
-                # Only when every attempt failed; the loop breaks on success.
-                raise SmartAuthError("Could not get vehicle information")
+                # Only when every attempt failed. Surface the real cause so a
+                # transient failure stays transient instead of a reauth prompt.
+                raise last_error
         return data
 
     async def get_vehicle_state(self, vin) -> dict:
@@ -441,6 +444,7 @@ class SmartAccount:
         }
         data = {}
         async with SmartClient(self.config) as client:
+            last_error = None
             for retry in range(3):
                 try:
                     r_car_info = await client.get(
@@ -464,18 +468,21 @@ class SmartAccount:
                     _LOGGER.debug("Got response %d", r_car_info.status_code)
                     self.vehicles.get(vin).combine_data(r_car_info.json()["data"])
                     data = r_car_info.json()["data"]
-                except SmartTokenRefreshNecessary:
+                except SmartTokenRefreshNecessary as exc:
+                    last_error = exc
                     _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
                     await self.config.authentication.refresh()
                     continue
-                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError) as exc:
+                    last_error = exc
                     _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
                     continue
                 break
             else:
-                # Only when every attempt failed; the loop breaks on success.
-                raise SmartAuthError("Could not get vehicle information")
+                # Only when every attempt failed. Surface the real cause so a
+                # transient failure stays transient instead of a reauth prompt.
+                raise last_error
         return data
 
     async def grant_journal_authorization(self, vin, force: bool = False) -> bool:
@@ -855,6 +862,7 @@ class SmartAccount:
         _LOGGER.debug("Getting OTA information for vehicle")
         data = {}
         async with SmartClient(self.config) as client:
+            last_error = None
             for retry in range(3):
                 try:
                     r_car_info = await client.get(
@@ -878,16 +886,19 @@ class SmartAccount:
                         "target_version": json_data.get("targetVersion"),
                         "current_version": json_data.get("currentVersion"),
                     }
-                except SmartTokenRefreshNecessary:
+                except SmartTokenRefreshNecessary as exc:
+                    last_error = exc
                     _LOGGER.debug("Session token expired; refreshing (retry %d)", retry)
                     await self.config.authentication.refresh()
                     continue
-                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError):
+                except (SmartHumanCarConnectionError, SmartVehicleNotInUseError) as exc:
+                    last_error = exc
                     _LOGGER.debug("VIN binding lost (8006/4038); re-binding vehicle (retry %d)", retry)
                     await self.select_active_vehicle(vin)
                     continue
                 break
             else:
-                # Only when every attempt failed; the loop breaks on success.
-                raise SmartAuthError("Could not get vehicle information")
+                # Only when every attempt failed. Surface the real cause so a
+                # transient failure stays transient instead of a reauth prompt.
+                raise last_error
         return data

--- a/pysmarthashtag/account.py
+++ b/pysmarthashtag/account.py
@@ -123,6 +123,12 @@ class SmartAccount:
     endpoint_urls: Optional[EndpointUrls] = None
     """Optional. Custom endpoint URLs for international API support."""
 
+    tracked_vins: Optional[list[str]] = None
+    """Optional. If set, only these VIN(s) are fetched and tracked; any other
+    vehicle on the account (e.g. a shared car that appears after switching
+    cars in the phone app) is ignored — no polling, no entities. ``None``
+    tracks every vehicle on the account (previous behaviour)."""
+
     vehicles: dict[str, SmartVehicle] = field(default_factory=dict, init=False)
     """Vehicles associated with the account."""
 
@@ -205,6 +211,10 @@ class SmartAccount:
                 break
 
             for vehicle in vehicles_response.json()["data"]["list"]:
+                vin = vehicle.get("vin")
+                if self.tracked_vins is not None and vin not in self.tracked_vins:
+                    _LOGGER.debug("Ignoring untracked vehicle %s", sanitize_log_data(vin))
+                    continue
                 _LOGGER.debug("Found vehicle %s", sanitize_log_data(vehicle))
                 self.add_vehicle(vehicle, fetched_at)
 

--- a/pysmarthashtag/api/authentication.py
+++ b/pysmarthashtag/api/authentication.py
@@ -563,7 +563,13 @@ class SmartAuthentication(httpx.Auth):
             },
             content=data.encode("utf-8"),
         )
-        api_result = r_api_access.json()
+        try:
+            api_result = r_api_access.json()
+        except ValueError as err:
+            raise SmartAPIError(
+                f"API session exchange returned non-JSON (HTTP {r_api_access.status_code}, "
+                f"body={sanitize_log_data(r_api_access.text[:200])!r})"
+            ) from err
         _LOGGER.debug("API session result: %s", sanitize_log_data(api_result))
         data_obj = api_result.get("data") if isinstance(api_result, dict) else None
         if isinstance(data_obj, dict) and data_obj.get("accessToken"):
@@ -653,7 +659,13 @@ class SmartAuthentication(httpx.Auth):
                 headers=headers,
                 content=body.encode("utf-8"),
             )
-        api_result = r.json()
+        try:
+            api_result = r.json()
+        except ValueError as err:
+            raise SmartAPIError(
+                f"Refresh-token exchange returned non-JSON (HTTP {r.status_code}, "
+                f"body={sanitize_log_data(r.text[:200])!r})"
+            ) from err
         _LOGGER.debug("Refresh-token exchange result: %s", sanitize_log_data(api_result))
         data_obj = api_result.get("data") if isinstance(api_result, dict) else None
         if isinstance(data_obj, dict) and data_obj.get("accessToken"):

--- a/pysmarthashtag/api/authentication.py
+++ b/pysmarthashtag/api/authentication.py
@@ -542,16 +542,10 @@ class SmartAuthentication(httpx.Auth):
     async def _post_api_session(self, client: "SmartLoginClient", access_token: str) -> dict:
         """Exchange an OAuth access token for a Smart API session (POST).
 
-        This is the final step of the full login flow AND the whole of the
-        cheap "layer 1" session refresh: POST the OAuth ``access_token`` to
-        ``/auth/account/session/secure`` and read the fresh API session tokens
-        (plus ``clientId``, needed for the refresh-token exchange) out of the
-        response ``data``.
-
-        Raises :class:`SmartMainTokenExpiredError` when the cloud reports the
-        OAuth token itself is dead (code 1501) so callers can escalate, and a
-        generic :class:`SmartAPIError` (carrying the cloud ``code``/``message``)
-        for any other missing-session response.
+        Used by the full login flow and by the layer-1 refresh. Raises
+        :class:`SmartMainTokenExpiredError` on code 1501 (the OAuth token itself
+        is dead) so callers can escalate, else :class:`SmartAPIError` carrying
+        the cloud ``code``/``message``.
         """
         data = json.dumps({"accessToken": access_token}).replace(" ", "")
         r_api_access = await client.post(
@@ -584,9 +578,9 @@ class SmartAuthentication(httpx.Auth):
         http_status = r_api_access.status_code
         if code == "1501":
             # Expected, handled condition: the OAuth token expired. refresh()
-            # recovers it (refresh-token exchange / full login) — not an error.
+            # recovers it (refresh-token exchange / full login), not an error.
             _LOGGER.info(
-                "API session: OAuth token expired (code=1501) — recovering via refresh()",
+                "API session: OAuth token expired (code=1501), recovering via refresh()",
             )
             raise SmartMainTokenExpiredError(
                 f"Main (OAuth) token expired (HTTP {http_status}, code=1501): {message}"
@@ -602,16 +596,11 @@ class SmartAuthentication(httpx.Auth):
         )
 
     async def refresh_api_session(self) -> None:
-        """Layer 1: refresh the API session token without a full re-login.
+        """Layer 1: refresh the API session without a full re-login.
 
-        Re-POSTs the stored OAuth ``access_token`` to the session endpoint to
-        obtain a fresh ``api_access_token``/``api_refresh_token``/``clientId``.
-        Far cheaper than the full Gigya flow, and — crucially — does not touch
-        the login gateway that rate-limits, so it can run every time a data
-        request reports the session token expired (1402/8006).
-
-        Raises :class:`SmartMainTokenExpiredError` if the OAuth token itself is
-        dead (caller should escalate to a refresh-token exchange / full login).
+        Re-POSTs the stored OAuth token to the session endpoint. Does not touch
+        the rate-limited login gateway. Raises
+        :class:`SmartMainTokenExpiredError` if that OAuth token is itself dead.
         """
         if not self.access_token:
             raise SmartMainTokenExpiredError("No OAuth access token available to refresh the session")
@@ -630,13 +619,10 @@ class SmartAuthentication(httpx.Auth):
     async def refresh_token_exchange(self) -> None:
         """Layer 2: exchange the API-session refresh token for a fresh OAuth token.
 
-        ``PUT /auth/account/session/secure`` (bare path, no query) with an
-        ``X-CLIENT-ID`` header and a body of
-        ``{"refreshToken": <api_refresh_token>, "proprietaryPlatform": "0"}``.
-        No Authorization header. The response's ``accessToken`` is the new
-        **OAuth** access token — the caller then re-runs layer 1 to mint a
-        fresh API session token from it. Avoids a full Gigya re-login when only
-        the OAuth token (not the session refresh token) has expired.
+        ``PUT`` the session endpoint (no query) with an ``X-CLIENT-ID`` header
+        and a ``{"refreshToken", "proprietaryPlatform"}`` body, no Authorization
+        header. The returned ``accessToken`` is the new OAuth token; the caller
+        then re-runs layer 1 with it.
         """
         if not self.api_refresh_token or not self.api_client_id:
             raise SmartAPIError(
@@ -688,7 +674,7 @@ class SmartAuthentication(httpx.Auth):
     async def refresh(self) -> None:
         """Refresh the session using the cheapest viable path.
 
-        Ladder (cheapest → most expensive):
+        Ladder, cheapest first:
           1. Refresh the API session with the stored OAuth token
              (:meth:`refresh_api_session`).
           2. On code 1501 (OAuth token expired): refresh-token exchange

--- a/pysmarthashtag/api/authentication.py
+++ b/pysmarthashtag/api/authentication.py
@@ -25,7 +25,7 @@ from pysmarthashtag.const import (
     WEBVIEW_USER_AGENT,
     EndpointUrls,
 )
-from pysmarthashtag.models import SmartAPIError
+from pysmarthashtag.models import SmartAPIError, SmartMainTokenExpiredError
 
 EXPIRES_AT_OFFSET = datetime.timedelta(seconds=HTTPX_TIMEOUT * 2)
 
@@ -80,6 +80,7 @@ class SmartAuthentication(httpx.Auth):
         self.api_access_token: Optional[str] = None
         self.api_refresh_token: Optional[str] = None
         self.api_user_id: Optional[str] = None
+        self.api_client_id: Optional[str] = None
         self.ssl_context: Optional[ssl.SSLContext] = ssl_context
         self.endpoint_urls: EndpointUrls = endpoint_urls if endpoint_urls is not None else EndpointUrls()
         # PATCH: shared adaptive-backoff state (per username, module-scoped).
@@ -171,13 +172,15 @@ class SmartAuthentication(httpx.Auth):
             raise
 
     async def login(self) -> None:
-        """Login to the Smart API."""
+        """Perform a full credential login (the layer-3 fallback).
+
+        Runs the complete Gigya/OIDC flow via ``_login`` (backoff-wrapped) and
+        stores the resulting OAuth + API session tokens. For a lightweight
+        refresh that avoids the rate-limited login gateway, prefer
+        :meth:`refresh`.
+        """
         _LOGGER.debug("Logging in to Smart API")
-        token_data = {}
-        if self.refresh_token:
-            token_data = await self._refresh_access_token()
-        if not token_data:
-            token_data = await self._login()
+        token_data = await self._login()
         try:
             token_data["expires_at"] = token_data["expires_at"] - EXPIRES_AT_OFFSET
 
@@ -186,22 +189,12 @@ class SmartAuthentication(httpx.Auth):
             self.api_access_token = token_data["api_access_token"]
             self.api_refresh_token = token_data["api_refresh_token"]
             self.api_user_id = token_data["api_user_id"]
+            self.api_client_id = token_data.get("api_client_id")
             self.expires_at = token_data["expires_at"]
             _LOGGER.debug("Login successful")
             return True
-        except KeyError:
+        except (KeyError, TypeError):
             raise SmartAPIError("Could not login to Smart API")
-
-    async def _refresh_access_token(self):
-        """Refresh the access token."""
-        try:
-            ssl_ctx = await self.get_ssl_context()
-            async with SmartLoginClient(ssl_context=ssl_ctx) as _:
-                _LOGGER.debug("Refreshing access token via relogin because refresh token is not implemented")
-                await self._login()
-        except SmartAPIError:
-            _LOGGER.debug("Refreshing access token failed. Logging in again")
-            return {}
 
     async def _login(self) -> dict:
         """Login to Smart web services with adaptive rate-limit backoff.
@@ -273,6 +266,12 @@ class SmartAuthentication(httpx.Auth):
             or "http 403" in text
             or "http 429" in text
             or "forbidden" in text
+            # Throttle wording the cloud may return as an HTTP-200 error body
+            # (surfaced into the exception text by the session-exchange handler).
+            # Kept narrow so genuine one-off failures are unaffected.
+            or "too many" in text
+            or "throttl" in text
+            or "try again later" in text
         )
 
     async def _do_login(self) -> dict:
@@ -528,41 +527,193 @@ class SmartAuthentication(httpx.Auth):
                 )
                 raise SmartAPIError("Could not get access token from auth page")
 
-            data = json.dumps({"accessToken": access_token}).replace(" ", "")
-            r_api_access = await client.post(
-                # we do not know what type of car we have in our list so we fall back to the old API URL
-                self.endpoint_urls.get_api_base_url() + API_SESION_URL + "?identity_type=smart",
-                headers={
-                    **utils.generate_default_header(
-                        self.device_id,
-                        None,
-                        params={
-                            "identity_type": "smart",
-                        },
-                        method="POST",
-                        url=API_SESION_URL,
-                        body=data,
-                    )
-                },
-                content=data.encode("utf-8"),
-            )
-            api_result = r_api_access.json()
-            _LOGGER.debug("API access result: %s", sanitize_log_data(api_result))
-            try:
-                api_access_token = api_result["data"]["accessToken"]
-                api_refresh_token = api_result["data"]["refreshToken"]
-                api_user_id = api_result["data"]["userId"]
-            except KeyError:
-                raise SmartAPIError("Could not get API access token from API")
+            api_tokens = await self._post_api_session(client, access_token)
 
         return {
             "access_token": access_token,
             "refresh_token": refresh_token,
-            "api_access_token": api_access_token,
-            "api_refresh_token": api_refresh_token,
-            "api_user_id": api_user_id,
+            "api_access_token": api_tokens["api_access_token"],
+            "api_refresh_token": api_tokens["api_refresh_token"],
+            "api_user_id": api_tokens["api_user_id"],
+            "api_client_id": api_tokens["api_client_id"],
             "expires_at": expires_at,
         }
+
+    async def _post_api_session(self, client: "SmartLoginClient", access_token: str) -> dict:
+        """Exchange an OAuth access token for a Smart API session (POST).
+
+        This is the final step of the full login flow AND the whole of the
+        cheap "layer 1" session refresh: POST the OAuth ``access_token`` to
+        ``/auth/account/session/secure`` and read the fresh API session tokens
+        (plus ``clientId``, needed for the refresh-token exchange) out of the
+        response ``data``.
+
+        Raises :class:`SmartMainTokenExpiredError` when the cloud reports the
+        OAuth token itself is dead (code 1501) so callers can escalate, and a
+        generic :class:`SmartAPIError` (carrying the cloud ``code``/``message``)
+        for any other missing-session response.
+        """
+        data = json.dumps({"accessToken": access_token}).replace(" ", "")
+        r_api_access = await client.post(
+            # we do not know what type of car we have in our list so we fall back to the old API URL
+            self.endpoint_urls.get_api_base_url() + API_SESION_URL + "?identity_type=smart",
+            headers={
+                **utils.generate_default_header(
+                    self.device_id,
+                    None,
+                    params={"identity_type": "smart"},
+                    method="POST",
+                    url=API_SESION_URL,
+                    body=data,
+                )
+            },
+            content=data.encode("utf-8"),
+        )
+        api_result = r_api_access.json()
+        _LOGGER.debug("API session result: %s", sanitize_log_data(api_result))
+        data_obj = api_result.get("data") if isinstance(api_result, dict) else None
+        if isinstance(data_obj, dict) and data_obj.get("accessToken"):
+            return {
+                "api_access_token": data_obj["accessToken"],
+                "api_refresh_token": data_obj.get("refreshToken"),
+                "api_user_id": data_obj.get("userId"),
+                "api_client_id": data_obj.get("clientId"),
+            }
+        code = str(api_result.get("code")) if isinstance(api_result, dict) else None
+        message = api_result.get("message", "") if isinstance(api_result, dict) else ""
+        http_status = r_api_access.status_code
+        if code == "1501":
+            # Expected, handled condition: the OAuth token expired. refresh()
+            # recovers it (refresh-token exchange / full login) — not an error.
+            _LOGGER.info(
+                "API session: OAuth token expired (code=1501) — recovering via refresh()",
+            )
+            raise SmartMainTokenExpiredError(
+                f"Main (OAuth) token expired (HTTP {http_status}, code=1501): {message}"
+            )
+        _LOGGER.error(
+            "API session exchange failed (HTTP %s, code=%s): %s",
+            http_status,
+            code,
+            sanitize_log_data(message),
+        )
+        raise SmartAPIError(
+            f"Could not get API access token from API (HTTP {http_status}, code={code}): {message}"
+        )
+
+    async def refresh_api_session(self) -> None:
+        """Layer 1: refresh the API session token without a full re-login.
+
+        Re-POSTs the stored OAuth ``access_token`` to the session endpoint to
+        obtain a fresh ``api_access_token``/``api_refresh_token``/``clientId``.
+        Far cheaper than the full Gigya flow, and — crucially — does not touch
+        the login gateway that rate-limits, so it can run every time a data
+        request reports the session token expired (1402/8006).
+
+        Raises :class:`SmartMainTokenExpiredError` if the OAuth token itself is
+        dead (caller should escalate to a refresh-token exchange / full login).
+        """
+        if not self.access_token:
+            raise SmartMainTokenExpiredError("No OAuth access token available to refresh the session")
+        ssl_ctx = await self.get_ssl_context()
+        async with SmartLoginClient(ssl_context=ssl_ctx) as client:
+            api_tokens = await self._post_api_session(client, self.access_token)
+        self.api_access_token = api_tokens["api_access_token"]
+        if api_tokens["api_refresh_token"]:
+            self.api_refresh_token = api_tokens["api_refresh_token"]
+        if api_tokens["api_user_id"]:
+            self.api_user_id = api_tokens["api_user_id"]
+        if api_tokens["api_client_id"]:
+            self.api_client_id = api_tokens["api_client_id"]
+        _LOGGER.info("Smart API session refreshed (layer 1, no re-login)")
+
+    async def refresh_token_exchange(self) -> None:
+        """Layer 2: exchange the API-session refresh token for a fresh OAuth token.
+
+        ``PUT /auth/account/session/secure`` (bare path, no query) with an
+        ``X-CLIENT-ID`` header and a body of
+        ``{"refreshToken": <api_refresh_token>, "proprietaryPlatform": "0"}``.
+        No Authorization header. The response's ``accessToken`` is the new
+        **OAuth** access token — the caller then re-runs layer 1 to mint a
+        fresh API session token from it. Avoids a full Gigya re-login when only
+        the OAuth token (not the session refresh token) has expired.
+        """
+        if not self.api_refresh_token or not self.api_client_id:
+            raise SmartAPIError(
+                "Cannot perform refresh-token exchange without api_refresh_token and api_client_id"
+            )
+        body = json.dumps({"refreshToken": self.api_refresh_token, "proprietaryPlatform": "0"}).replace(" ", "")
+        headers = utils.generate_default_header(
+            self.device_id,
+            None,
+            params={},
+            method="PUT",
+            url=API_SESION_URL,
+            body=body,
+        )
+        headers["X-CLIENT-ID"] = self.api_client_id
+        # Diagnostic: capture exactly what we send (sanitized) so a rejection
+        # (e.g. code 1400 "Illegal parameter") can be compared to the app.
+        _LOGGER.debug(
+            "Refresh-token exchange request: PUT %s | header_keys=%s | body=%s",
+            API_SESION_URL,
+            sorted(headers.keys()),
+            sanitize_log_data({"refreshToken": self.api_refresh_token, "proprietaryPlatform": "0"}),
+        )
+        ssl_ctx = await self.get_ssl_context()
+        async with SmartLoginClient(ssl_context=ssl_ctx) as client:
+            r = await client.put(
+                self.endpoint_urls.get_api_base_url() + API_SESION_URL,
+                headers=headers,
+                content=body.encode("utf-8"),
+            )
+        api_result = r.json()
+        _LOGGER.debug("Refresh-token exchange result: %s", sanitize_log_data(api_result))
+        data_obj = api_result.get("data") if isinstance(api_result, dict) else None
+        if isinstance(data_obj, dict) and data_obj.get("accessToken"):
+            # This accessToken is the new OAuth token (feeds layer 1's body).
+            self.access_token = data_obj["accessToken"]
+            if data_obj.get("refreshToken"):
+                self.api_refresh_token = data_obj["refreshToken"]
+            if data_obj.get("clientId"):
+                self.api_client_id = data_obj["clientId"]
+            _LOGGER.info("Smart API refresh-token exchange succeeded (layer 2)")
+            return
+        code = str(api_result.get("code")) if isinstance(api_result, dict) else None
+        message = api_result.get("message", "") if isinstance(api_result, dict) else ""
+        raise SmartAPIError(
+            f"Refresh-token exchange failed (HTTP {r.status_code}, code={code}): {message}"
+        )
+
+    async def refresh(self) -> None:
+        """Refresh the session using the cheapest viable path.
+
+        Ladder (cheapest → most expensive):
+          1. Refresh the API session with the stored OAuth token
+             (:meth:`refresh_api_session`).
+          2. On code 1501 (OAuth token expired): refresh-token exchange
+             (:meth:`refresh_token_exchange`) to recover the OAuth token, then
+             re-run layer 1 to mint a fresh session token from it.
+          3. Full credential re-login (:meth:`login`), backoff-wrapped.
+        """
+        try:
+            await self.refresh_api_session()
+            return
+        except SmartMainTokenExpiredError as exc:
+            _LOGGER.info("Layer-1: OAuth token expired (%s); attempting refresh-token exchange", exc)
+        except SmartAPIError as exc:
+            _LOGGER.info("Layer-1 refresh failed (%s); falling back to full login", exc)
+            await self.login()
+            return
+        # Reached only when layer 1 reported 1501: recover the OAuth token via
+        # the refresh-token exchange, then re-run layer 1 to mint a session token.
+        try:
+            await self.refresh_token_exchange()
+            await self.refresh_api_session()
+            return
+        except SmartAPIError as exc:
+            _LOGGER.info("Refresh-token exchange path failed (%s); falling back to full login", exc)
+        await self.login()
 
 
 class SmartLoginClient(httpx.AsyncClient):

--- a/pysmarthashtag/api/client.py
+++ b/pysmarthashtag/api/client.py
@@ -113,7 +113,7 @@ class SmartClient(httpx.AsyncClient):
                 return
             # Map cloud error codes to typed exceptions and let the CALLER decide
             # the remedy (refresh / re-bind VIN / surface). We intentionally do
-            # NOT log in or re-bind here — collapsing every code into a full
+            # NOT log in or re-bind here. Collapsing every code into a full
             # re-login is what wedged the integration into `unavailable`.
             if code == "1402":
                 raise SmartTokenRefreshNecessary("Session token expired (code=1402)")

--- a/pysmarthashtag/api/client.py
+++ b/pysmarthashtag/api/client.py
@@ -15,7 +15,12 @@ from pysmarthashtag.const import (
 from pysmarthashtag.models import (
     AnonymizedResponse,
     SmartHumanCarConnectionError,
+    SmartMainTokenExpiredError,
+    SmartNoPermissionError,
+    SmartNonceError,
     SmartTokenRefreshNecessary,
+    SmartVehicleNotInUseError,
+    SmartVehicleUnboundError,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -100,21 +105,37 @@ class SmartClient(httpx.AsyncClient):
             Will read out response JSON for code and message
             """
             response_data = response.json()
-            if "message" in response_data:
-                self.last_message = response_data["message"]
-            if "code" in response_data and response_data["code"] == "1402":
-                await self.config.authentication.login()
-                raise SmartTokenRefreshNecessary("Token expired, refresh token, do request again.")
-            if "code" in response_data and response_data["code"] == "8006":
+            code = str(response_data["code"]) if "code" in response_data else None
+            message = response_data.get("message", "")
+            if message:
+                self.last_message = message
+            if code is None or code in ("1000", "200", "0"):
+                return
+            # Map cloud error codes to typed exceptions and let the CALLER decide
+            # the remedy (refresh / re-bind VIN / surface). We intentionally do
+            # NOT log in or re-bind here — collapsing every code into a full
+            # re-login is what wedged the integration into `unavailable`.
+            if code == "1402":
+                raise SmartTokenRefreshNecessary("Session token expired (code=1402)")
+            if code == "8006":
                 raise SmartHumanCarConnectionError(
-                    "Human and vehicle relationship does not exist, selct car and do request again."
+                    "Human and vehicle relationship does not exist, select car and do request again."
                 )
-            elif "code" in response_data and response_data["code"] != "1000" and "message" in response_data:
-                raise httpx.HTTPStatusError(
-                    response=response,
-                    request=response.request,
-                    message=f"{response_data['code']}: {response_data['message']}",
-                )
+            if code == "1501":
+                raise SmartMainTokenExpiredError(f"Main (OAuth) token expired (code=1501): {message}")
+            if code == "4038":
+                raise SmartVehicleNotInUseError(f"Vehicle not in use (code=4038): {message}")
+            if code == "8040":
+                raise SmartVehicleUnboundError(f"VIN not bound to account (code=8040): {message}")
+            if code == "1443":
+                raise SmartNonceError(f"Request nonce repeated (code=1443): {message}")
+            if code == "8160":
+                raise SmartNoPermissionError(f"No permission (code=8160): {message}")
+            raise httpx.HTTPStatusError(
+                response=response,
+                request=response.request,
+                message=f"{code}: {message}",
+            )
 
         kwargs["event_hooks"]["response"].append(raise_for_status_event_handler)
 

--- a/pysmarthashtag/api/client.py
+++ b/pysmarthashtag/api/client.py
@@ -123,6 +123,14 @@ class SmartClient(httpx.AsyncClient):
                 )
             if code == "1501":
                 raise SmartMainTokenExpiredError(f"Main (OAuth) token expired (code=1501): {message}")
+            if code == "8500":
+                # Seen once, with an empty message, and it behaved exactly like a
+                # main token expiry: requests kept failing until the token was
+                # replaced. Treated as 1501 until a counter-example shows up.
+                # Logged at WARNING so further occurrences are visible without
+                # turning on debug.
+                _LOGGER.warning("Cloud returned 8500 (treated as main token expiry). Message: %r", message)
+                raise SmartMainTokenExpiredError(f"Main (OAuth) token expired (code=8500): {message}")
             if code == "4038":
                 raise SmartVehicleNotInUseError(f"Vehicle not in use (code=4038): {message}")
             if code == "8040":

--- a/pysmarthashtag/api/utils.py
+++ b/pysmarthashtag/api/utils.py
@@ -4,6 +4,7 @@ import hmac
 import logging
 import secrets
 import time
+from typing import Optional
 from urllib.parse import quote
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,8 +47,8 @@ def generate_default_header(
     method: str,
     url: str,
     body=None,
-    vin: str = None,
-    model_code: str = None,
+    vin: Optional[str] = None,
+    model_code: Optional[str] = None,
 ) -> dict[str, str]:
     """Generate a header for HTTP requests to the server.
 

--- a/pysmarthashtag/api/utils.py
+++ b/pysmarthashtag/api/utils.py
@@ -4,8 +4,13 @@ import hmac
 import logging
 import secrets
 import time
+from urllib.parse import quote
 
 _LOGGER = logging.getLogger(__name__)
+
+# Endpoints that must NOT carry the per-request X-Vehicle-* headers (the VIN is
+# irrelevant there / already travels in the request body).
+_VIN_HEADER_BLACKLIST = ("/user/session/update", "/geelyTCAccess/tcservices/capability/")
 
 
 def join_url_params(args: dict) -> str:
@@ -35,9 +40,24 @@ x-api-signature-version:1.0
 
 
 def generate_default_header(
-    device_id: str, access_token: str, params: dict, method: str, url: str, body=None
+    device_id: str,
+    access_token: str,
+    params: dict,
+    method: str,
+    url: str,
+    body=None,
+    vin: str = None,
+    model_code: str = None,
 ) -> dict[str, str]:
-    """Generate a header for HTTP requests to the server."""
+    """Generate a header for HTTP requests to the server.
+
+    When ``vin`` (and ideally ``model_code``, the vehicle ``matCode``) are
+    provided, per-request VIN-binding headers (``X-Vehicle-IDENTIFIER`` /
+    ``X-VEHICLE-SERIES`` / ``X-VEHICLE-MODEL``) are added. These carry the VIN
+    context per request so the server does not rely on the account-wide
+    "active vehicle" session binding, which another client (the phone app) can
+    steal by switching cars.
+    """
     timestamp = create_correct_timestamp()
     nonce = secrets.token_hex(8)
     sign = _create_sign(nonce, params, timestamp, method, url, body)
@@ -64,6 +84,13 @@ def generate_default_header(
     }
     if access_token:
         header["authorization"] = access_token
+
+    # Per-request VIN-binding headers (see docstring). Skip blacklisted endpoints.
+    if vin and model_code and not any(b in url for b in _VIN_HEADER_BLACKLIST):
+        encoded = quote(model_code, safe="")
+        header["X-Vehicle-IDENTIFIER"] = vin
+        header["X-VEHICLE-SERIES"] = encoded
+        header["X-VEHICLE-MODEL"] = encoded
 
     _LOGGER.debug("Constructed request header for %s %s", method, url)
     return header

--- a/pysmarthashtag/api/utils.py
+++ b/pysmarthashtag/api/utils.py
@@ -51,12 +51,9 @@ def generate_default_header(
 ) -> dict[str, str]:
     """Generate a header for HTTP requests to the server.
 
-    When ``vin`` (and ideally ``model_code``, the vehicle ``matCode``) are
-    provided, per-request VIN-binding headers (``X-Vehicle-IDENTIFIER`` /
-    ``X-VEHICLE-SERIES`` / ``X-VEHICLE-MODEL``) are added. These carry the VIN
-    context per request so the server does not rely on the account-wide
-    "active vehicle" session binding, which another client (the phone app) can
-    steal by switching cars.
+    With ``vin`` and ``model_code`` (the vehicle ``matCode``), adds the
+    per-request VIN headers so the server does not rely on the account-wide
+    "active vehicle" binding, which another client can steal by switching cars.
     """
     timestamp = create_correct_timestamp()
     nonce = secrets.token_hex(8)

--- a/pysmarthashtag/models.py
+++ b/pysmarthashtag/models.py
@@ -88,6 +88,46 @@ class SmartHumanCarConnectionError(SmartAPIError):
     """Human and vehicle connection does not exist (Response Code 8006)."""
 
 
+class SmartVehicleNotInUseError(SmartAPIError):
+    """Current vehicle is not in use (Response Code 4038).
+
+    Transient: the cloud lost the per-session VIN binding (often because
+    another client/VIN-switch rebound to a different vehicle). Remedy is to
+    re-bind the VIN (``select_active_vehicle``) and retry the request — NOT
+    to refresh or re-login (that wastes a round-trip and does not help).
+    """
+
+
+class SmartVehicleUnboundError(SmartAPIError):
+    """VIN no longer bound to this account/UID (Response Code 8040).
+
+    Terminal for the affected VIN: the vehicle is genuinely unbound (e.g. a
+    shared key was given up, or the car was removed from the account). Not
+    recoverable by token refresh or re-login — the user must re-add the
+    vehicle in the Smart app. Callers should surface this rather than retry.
+    """
+
+
+class SmartMainTokenExpiredError(SmartAPIError):
+    """The main (OAuth) access token has expired (Response Code 1501).
+
+    The cheap API-session refresh cannot recover this; a refresh-token
+    exchange (or, failing that, a full credential re-login) is required.
+    """
+
+
+class SmartNonceError(SmartAPIError):
+    """Request signature nonce was repeated (Response Code 1443).
+
+    Remedy is to retry with a freshly generated nonce/timestamp (the header
+    generator produces new ones per request) — never a token op.
+    """
+
+
+class SmartNoPermissionError(SmartAPIError):
+    """Caller lacks permission for the requested resource (Response Code 8160)."""
+
+
 class SmartQuotaError(SmartAPIError):
     """Quota exceeded on Smart web API."""
 

--- a/pysmarthashtag/models.py
+++ b/pysmarthashtag/models.py
@@ -93,7 +93,7 @@ class SmartVehicleNotInUseError(SmartAPIError):
 
     Transient: the cloud lost the per-session VIN binding (often because
     another client/VIN-switch rebound to a different vehicle). Remedy is to
-    re-bind the VIN (``select_active_vehicle``) and retry the request — NOT
+    re-bind the VIN (``select_active_vehicle``) and retry the request, NOT
     to refresh or re-login (that wastes a round-trip and does not help).
     """
 
@@ -103,7 +103,7 @@ class SmartVehicleUnboundError(SmartAPIError):
 
     Terminal for the affected VIN: the vehicle is genuinely unbound (e.g. a
     shared key was given up, or the car was removed from the account). Not
-    recoverable by token refresh or re-login — the user must re-add the
+    recoverable by token refresh or re-login: the user must re-add the
     vehicle in the Smart app. Callers should surface this rather than retry.
     """
 
@@ -120,7 +120,7 @@ class SmartNonceError(SmartAPIError):
     """Request signature nonce was repeated (Response Code 1443).
 
     Remedy is to retry with a freshly generated nonce/timestamp (the header
-    generator produces new ones per request) — never a token op.
+    generator produces new ones per request), never a token op.
     """
 
 

--- a/pysmarthashtag/tests/test_account.py
+++ b/pysmarthashtag/tests/test_account.py
@@ -5,7 +5,7 @@ import respx
 from httpx import Request, Response
 
 from pysmarthashtag.const import API_BASE_URL, API_SELECT_CAR_URL
-from pysmarthashtag.models import ValueWithUnit
+from pysmarthashtag.models import SmartTokenRefreshNecessary, ValueWithUnit
 from pysmarthashtag.tests import RESPONSE_DIR, load_response
 from pysmarthashtag.tests.conftest import prepare_account_with_vehicles
 
@@ -105,3 +105,21 @@ async def test_get_vehicle_chargin_dc(smart_fixture: respx.Router):
     assert vehicles["TestVIN0000000002"].battery.charging_current == ValueWithUnit(value=102.6, unit="A")
     assert vehicles["TestVIN0000000002"].battery.charging_voltage == ValueWithUnit(value=429, unit="V")
     assert vehicles["TestVIN0000000002"].battery.charging_power == ValueWithUnit(value=44015, unit="W")
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retries_surface_real_cause(smart_fixture: respx.Router):
+    """When every retry fails, the underlying cause is raised, not a generic auth error.
+
+    A transient cloud failure should stay transient so the caller can retry,
+    instead of being reported as an authentication problem.
+    """
+    account = await prepare_account_with_vehicles()
+
+    # Every attempt now fails with 1402, so the retry loop is exhausted.
+    smart_fixture.get(
+        API_BASE_URL + "/remote-control/vehicle/status/TestVIN0000000001?latest=True&target=basic%2Cmore&userId=112233"
+    ).mock(return_value=Response(200, json=load_response(RESPONSE_DIR / "token_expired.json")))
+
+    with pytest.raises(SmartTokenRefreshNecessary):
+        await account.get_vehicle_information("TestVIN0000000001")

--- a/pysmarthashtag/tests/test_account.py
+++ b/pysmarthashtag/tests/test_account.py
@@ -1,5 +1,6 @@
 import logging
 
+import httpx
 import pytest
 import respx
 from httpx import Request, Response
@@ -55,6 +56,40 @@ async def test_get_vehicles_token_expired(smart_fixture: respx.Router):
     await account.get_vehicle_information("TestVIN0000000001")
 
     assert account.vehicles["TestVIN0000000001"].engine_state == "engine_running"
+
+
+@pytest.mark.asyncio
+async def test_unmapped_code_refreshes_once_then_recovers(smart_fixture: respx.Router):
+    """A cloud code with no typed remedy gets one refresh, then the retry succeeds."""
+
+    def switch_response(request: Request, route: respx.Route) -> Response:
+        if route.call_count == 1:
+            return Response(200, json={"code": "9999", "message": "something new"})
+        name = "vehicle_info.json" if route.call_count == 0 else "vehicle_info2.json"
+        return Response(200, json=load_response(RESPONSE_DIR / name))
+
+    smart_fixture.get(
+        API_BASE_URL + "/remote-control/vehicle/status/TestVIN0000000001?latest=True&target=basic%2Cmore&userId=112233"
+    ).mock(side_effect=switch_response)
+
+    account = await prepare_account_with_vehicles()
+    assert account.vehicles["TestVIN0000000001"].engine_state == "engine_off"
+
+    await account.get_vehicle_information("TestVIN0000000001")
+    assert account.vehicles["TestVIN0000000001"].engine_state == "engine_running"
+
+
+@pytest.mark.asyncio
+async def test_unmapped_code_surfaces_if_refresh_does_not_help(smart_fixture: respx.Router):
+    """The refresh is tried once only; a persistent unmapped code still surfaces."""
+    account = await prepare_account_with_vehicles()
+
+    smart_fixture.get(
+        API_BASE_URL + "/remote-control/vehicle/status/TestVIN0000000001?latest=True&target=basic%2Cmore&userId=112233"
+    ).mock(return_value=Response(200, json={"code": "9999", "message": "still broken"}))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await account.get_vehicle_information("TestVIN0000000001")
 
 
 @pytest.mark.asyncio

--- a/pysmarthashtag/tests/test_token_lifecycle.py
+++ b/pysmarthashtag/tests/test_token_lifecycle.py
@@ -2,13 +2,13 @@
 
 Covers the pieces added on ``feat/token-lifecycle``:
 
-* ``_post_api_session`` — success parsing (incl. ``clientId``) and typed
+* ``_post_api_session``: success parsing (incl. ``clientId``) and typed
   classification of failures (1501 vs generic).
-* ``refresh_api_session`` — layer-1 refresh updates session fields from the
+* ``refresh_api_session``: layer-1 refresh updates session fields from the
   stored OAuth token.
-* ``refresh`` — orchestrates layer 1 → full-login fallback.
-* ``login`` — captures ``api_client_id``.
-* ``SmartClient`` response routing — cloud codes map to typed exceptions and
+* ``refresh``: orchestrates layer 1 to full-login fallback.
+* ``login``: captures ``api_client_id``.
+* ``SmartClient`` response routing: cloud codes map to typed exceptions and
   no longer log in inline.
 """
 

--- a/pysmarthashtag/tests/test_token_lifecycle.py
+++ b/pysmarthashtag/tests/test_token_lifecycle.py
@@ -363,6 +363,7 @@ class TestClientRouting:
             ("1402", SmartTokenRefreshNecessary),
             ("8006", SmartHumanCarConnectionError),
             ("1501", SmartMainTokenExpiredError),
+            ("8500", SmartMainTokenExpiredError),
             ("4038", SmartVehicleNotInUseError),
             ("8040", SmartVehicleUnboundError),
             ("1443", SmartNonceError),
@@ -374,6 +375,17 @@ class TestClientRouting:
         try:
             with pytest.raises(exc):
                 await _run_response_hooks(client, {"code": code, "message": "m"})
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_8500_without_message_warns(self, caplog):
+        """8500 was observed with no message at all, and must still be typed and logged."""
+        client = self._client()
+        try:
+            with pytest.raises(SmartMainTokenExpiredError):
+                await _run_response_hooks(client, {"code": "8500"})
+            assert "8500" in caplog.text
         finally:
             await client.aclose()
 

--- a/pysmarthashtag/tests/test_token_lifecycle.py
+++ b/pysmarthashtag/tests/test_token_lifecycle.py
@@ -140,6 +140,29 @@ class TestPostApiSession:
         assert "9999" in str(excinfo.value)
         assert not isinstance(excinfo.value, SmartMainTokenExpiredError)
 
+    @pytest.mark.asyncio
+    async def test_non_json_response_raises_api_error(self):
+        """A maintenance/WAF page (HTML, not JSON) surfaces as SmartAPIError.
+
+        Without the guard the raw ValueError escapes the SmartAPIError
+        contract refresh()/_login() rely on, defeating the full-login
+        fallback and rate-limit backoff.
+        """
+
+        class _HtmlResponse:
+            status_code = 503
+            text = "<html><body>Service under maintenance</body></html>"
+
+            def json(self):
+                raise ValueError("no json")
+
+        auth = _make_auth()
+        client = _FakeClient(_HtmlResponse())
+        with pytest.raises(SmartAPIError) as excinfo:
+            await auth._post_api_session(client, "oauth-token")
+        assert "503" in str(excinfo.value)
+        assert not isinstance(excinfo.value, SmartMainTokenExpiredError)
+
 
 # ---- refresh_api_session / refresh ----------------------------------------
 

--- a/pysmarthashtag/tests/test_token_lifecycle.py
+++ b/pysmarthashtag/tests/test_token_lifecycle.py
@@ -1,0 +1,401 @@
+"""Tests for the layered token/session lifecycle.
+
+Covers the pieces added on ``feat/token-lifecycle``:
+
+* ``_post_api_session`` — success parsing (incl. ``clientId``) and typed
+  classification of failures (1501 vs generic).
+* ``refresh_api_session`` — layer-1 refresh updates session fields from the
+  stored OAuth token.
+* ``refresh`` — orchestrates layer 1 → full-login fallback.
+* ``login`` — captures ``api_client_id``.
+* ``SmartClient`` response routing — cloud codes map to typed exceptions and
+  no longer log in inline.
+"""
+
+from __future__ import annotations
+
+import datetime
+import ssl
+
+import httpx
+import pytest
+
+import pysmarthashtag.api.authentication as auth_module
+from pysmarthashtag.api.authentication import _BACKOFF_REGISTRY, SmartAuthentication
+from pysmarthashtag.api.client import SmartClient, SmartClientConfiguration
+from pysmarthashtag.models import (
+    SmartAPIError,
+    SmartHumanCarConnectionError,
+    SmartMainTokenExpiredError,
+    SmartNoPermissionError,
+    SmartNonceError,
+    SmartTokenRefreshNecessary,
+    SmartVehicleNotInUseError,
+    SmartVehicleUnboundError,
+)
+
+
+def _make_auth(username: str = "lifecycle@example.com") -> SmartAuthentication:
+    _BACKOFF_REGISTRY.pop(username, None)
+    return SmartAuthentication(username=username, password="p")
+
+
+def _token_data() -> dict:
+    return {
+        "access_token": "a",
+        "refresh_token": "r",
+        "api_access_token": "x",
+        "api_refresh_token": "y",
+        "api_user_id": "z",
+        "expires_at": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
+    }
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    """Stand-in for SmartLoginClient exposing only the ``post`` used here."""
+
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.calls: list = []
+
+    async def post(self, url, headers=None, content=None):
+        self.calls.append((url, headers, content))
+        return self._response
+
+
+class _FakeAsyncClient:
+    """Async-context stand-in for ``SmartLoginClient`` (put/post + aenter/aexit)."""
+
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.calls: list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def put(self, url, headers=None, content=None):
+        self.calls.append(("PUT", url, headers, content))
+        return self._response
+
+    async def post(self, url, headers=None, content=None):
+        self.calls.append(("POST", url, headers, content))
+        return self._response
+
+
+# ---- _post_api_session -----------------------------------------------------
+
+
+class TestPostApiSession:
+    @pytest.mark.asyncio
+    async def test_success_captures_client_id(self):
+        auth = _make_auth()
+        client = _FakeClient(
+            _FakeResponse(
+                {
+                    "code": "1000",
+                    "data": {
+                        "accessToken": "AT",
+                        "refreshToken": "RT",
+                        "userId": "UID",
+                        "clientId": "CID",
+                    },
+                }
+            )
+        )
+        tokens = await auth._post_api_session(client, "oauth-token")
+        assert tokens == {
+            "api_access_token": "AT",
+            "api_refresh_token": "RT",
+            "api_user_id": "UID",
+            "api_client_id": "CID",
+        }
+        # the OAuth token, not the api token, is sent in the body
+        assert "oauth-token" in client.calls[0][2].decode()
+
+    @pytest.mark.asyncio
+    async def test_1501_raises_main_token_expired(self):
+        auth = _make_auth()
+        client = _FakeClient(_FakeResponse({"code": "1501", "message": "main token expired"}))
+        with pytest.raises(SmartMainTokenExpiredError):
+            await auth._post_api_session(client, "oauth-token")
+
+    @pytest.mark.asyncio
+    async def test_generic_error_carries_code(self):
+        auth = _make_auth()
+        client = _FakeClient(_FakeResponse({"code": "9999", "message": "nope"}))
+        with pytest.raises(SmartAPIError) as excinfo:
+            await auth._post_api_session(client, "oauth-token")
+        assert "9999" in str(excinfo.value)
+        assert not isinstance(excinfo.value, SmartMainTokenExpiredError)
+
+
+# ---- refresh_api_session / refresh ----------------------------------------
+
+
+class TestRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_api_session_updates_fields(self, monkeypatch):
+        auth = _make_auth()
+        auth.access_token = "oauth-token"
+
+        async def fake_ssl():
+            return ssl.create_default_context()
+
+        async def fake_post(client, token):
+            assert token == "oauth-token"
+            return {
+                "api_access_token": "AT2",
+                "api_refresh_token": "RT2",
+                "api_user_id": "UID2",
+                "api_client_id": "CID2",
+            }
+
+        monkeypatch.setattr(auth, "get_ssl_context", fake_ssl)
+        monkeypatch.setattr(auth, "_post_api_session", fake_post)
+        await auth.refresh_api_session()
+        assert auth.api_access_token == "AT2"
+        assert auth.api_refresh_token == "RT2"
+        assert auth.api_user_id == "UID2"
+        assert auth.api_client_id == "CID2"
+
+    @pytest.mark.asyncio
+    async def test_refresh_api_session_without_oauth_token_raises(self):
+        auth = _make_auth()
+        auth.access_token = None
+        with pytest.raises(SmartMainTokenExpiredError):
+            await auth.refresh_api_session()
+
+    @pytest.mark.asyncio
+    async def test_refresh_uses_layer1_and_skips_full_login(self, monkeypatch):
+        auth = _make_auth()
+        calls: list[str] = []
+
+        async def layer1():
+            calls.append("layer1")
+
+        async def full_login():
+            calls.append("login")
+
+        monkeypatch.setattr(auth, "refresh_api_session", layer1)
+        monkeypatch.setattr(auth, "login", full_login)
+        await auth.refresh()
+        assert calls == ["layer1"], "full login should not run when layer-1 succeeds"
+
+    @pytest.mark.asyncio
+    async def test_refresh_1501_uses_layer2_then_reruns_layer1(self, monkeypatch):
+        """On 1501, layer-2 recovers the OAuth token, then layer-1 re-runs."""
+        auth = _make_auth()
+        calls: list[str] = []
+        layer1_calls = {"n": 0}
+
+        async def layer1():
+            layer1_calls["n"] += 1
+            calls.append(f"layer1#{layer1_calls['n']}")
+            if layer1_calls["n"] == 1:
+                raise SmartMainTokenExpiredError("oauth dead")
+            # second call (after layer-2) succeeds
+
+        async def layer2():
+            calls.append("layer2")
+
+        async def full_login():
+            calls.append("login")
+
+        monkeypatch.setattr(auth, "refresh_api_session", layer1)
+        monkeypatch.setattr(auth, "refresh_token_exchange", layer2)
+        monkeypatch.setattr(auth, "login", full_login)
+        await auth.refresh()
+        assert calls == ["layer1#1", "layer2", "layer1#2"], "should recover via layer-2 then re-run layer-1"
+        assert "login" not in calls, "must not fall to full login when layer-2 recovers"
+
+    @pytest.mark.asyncio
+    async def test_refresh_falls_back_to_login_when_layer2_fails(self, monkeypatch):
+        auth = _make_auth()
+        calls: list[str] = []
+
+        async def layer1():
+            calls.append("layer1")
+            raise SmartMainTokenExpiredError("oauth dead")
+
+        async def layer2():
+            calls.append("layer2")
+            raise SmartAPIError("exchange failed")
+
+        async def full_login():
+            calls.append("login")
+
+        monkeypatch.setattr(auth, "refresh_api_session", layer1)
+        monkeypatch.setattr(auth, "refresh_token_exchange", layer2)
+        monkeypatch.setattr(auth, "login", full_login)
+        await auth.refresh()
+        assert calls == ["layer1", "layer2", "login"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_exchange_updates_oauth_token(self, monkeypatch):
+        auth = _make_auth()
+        auth.api_refresh_token = "SRT"
+        auth.api_client_id = "CID"
+        fake = _FakeAsyncClient(
+            _FakeResponse(
+                {"code": "1000", "data": {"accessToken": "NEW_OAUTH", "refreshToken": "SRT2", "clientId": "CID2"}}
+            )
+        )
+
+        async def fake_ssl():
+            return ssl.create_default_context()
+
+        monkeypatch.setattr(auth, "get_ssl_context", fake_ssl)
+        monkeypatch.setattr(auth_module, "SmartLoginClient", lambda **kw: fake)
+        await auth.refresh_token_exchange()
+        assert auth.access_token == "NEW_OAUTH"
+        assert auth.api_refresh_token == "SRT2"
+        assert auth.api_client_id == "CID2"
+        method, url, headers, content = fake.calls[0]
+        assert method == "PUT"
+        assert headers["X-CLIENT-ID"] == "CID"
+        assert "proprietaryPlatform" in content.decode()
+        assert "identity_type" not in url  # bare path, no query
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_exchange_requires_client_id(self):
+        auth = _make_auth()
+        auth.api_refresh_token = "SRT"
+        auth.api_client_id = None
+        with pytest.raises(SmartAPIError):
+            await auth.refresh_token_exchange()
+
+    @pytest.mark.asyncio
+    async def test_refresh_falls_back_to_login_on_generic_error(self, monkeypatch):
+        auth = _make_auth()
+        calls: list[str] = []
+
+        async def layer1():
+            raise SmartAPIError("boom")
+
+        async def full_login():
+            calls.append("login")
+
+        monkeypatch.setattr(auth, "refresh_api_session", layer1)
+        monkeypatch.setattr(auth, "login", full_login)
+        await auth.refresh()
+        assert calls == ["login"]
+
+
+class TestLoginCapturesClientId:
+    @pytest.mark.asyncio
+    async def test_login_stores_api_client_id(self, monkeypatch):
+        auth = _make_auth()
+
+        async def fake_login():
+            data = _token_data()
+            data["api_client_id"] = "CID"
+            return data
+
+        monkeypatch.setattr(auth, "_login", fake_login)
+        await auth.login()
+        assert auth.api_client_id == "CID"
+        assert auth.api_access_token == "x"
+
+
+# ---- SmartClient response-code routing ------------------------------------
+
+
+async def _run_response_hooks(client: SmartClient, payload: dict, status: int = 200) -> None:
+    req = httpx.Request("GET", "https://example/api")
+    resp = httpx.Response(status, json=payload, request=req)
+    for hook in client.event_hooks["response"]:
+        await hook(resp)
+
+
+class TestClientRouting:
+    def _client(self) -> SmartClient:
+        auth = _make_auth("routing@example.com")
+        config = SmartClientConfiguration(authentication=auth)
+        return SmartClient(config, ssl_context=ssl.create_default_context())
+
+    @pytest.mark.asyncio
+    async def test_success_code_does_not_raise(self):
+        client = self._client()
+        try:
+            await _run_response_hooks(client, {"code": "1000", "data": {}})
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "code,exc",
+        [
+            ("1402", SmartTokenRefreshNecessary),
+            ("8006", SmartHumanCarConnectionError),
+            ("1501", SmartMainTokenExpiredError),
+            ("4038", SmartVehicleNotInUseError),
+            ("8040", SmartVehicleUnboundError),
+            ("1443", SmartNonceError),
+            ("8160", SmartNoPermissionError),
+        ],
+    )
+    async def test_error_codes_map_to_typed_exceptions(self, code, exc):
+        client = self._client()
+        try:
+            with pytest.raises(exc):
+                await _run_response_hooks(client, {"code": code, "message": "m"})
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_token_expiry_does_not_login_inline(self, monkeypatch):
+        """The event hook must NOT perform the remedy itself anymore."""
+        client = self._client()
+        logged_in = {"n": 0}
+
+        async def fake_login():
+            logged_in["n"] += 1
+
+        monkeypatch.setattr(client.config.authentication, "login", fake_login)
+        try:
+            with pytest.raises(SmartTokenRefreshNecessary):
+                await _run_response_hooks(client, {"code": "1402"})
+        finally:
+            await client.aclose()
+        assert logged_in["n"] == 0, "client hook should not log in inline"
+
+
+class TestRateLimitClassification:
+    """Ported from #213: throttle wording must feed the geometric backoff."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Too Many Requests",
+            "request throttled, slow down",
+            "please try again later",
+            "Could not get API access token from API (HTTP 429, code=...): x",
+            "HTTP 403 Forbidden",
+            "rate limit exceeded",
+        ],
+    )
+    def test_rate_limit_texts_classified(self, text):
+        assert SmartAuthentication._is_rate_limit_error(SmartAPIError(text))
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Could not get access token from auth page",
+            "Could not get context from login page",
+            "some transient network blip",
+        ],
+    )
+    def test_non_rate_limit_texts_not_classified(self, text):
+        assert not SmartAuthentication._is_rate_limit_error(SmartAPIError(text))

--- a/pysmarthashtag/tests/test_tracked_vins.py
+++ b/pysmarthashtag/tests/test_tracked_vins.py
@@ -8,7 +8,7 @@ from pysmarthashtag.tests import TEST_PASSWORD, TEST_USERNAME
 
 @pytest.mark.asyncio
 async def test_tracked_vins_filters_out_other_vehicles(smart_fixture):
-    """With tracked_vins set, only that VIN is added — others are ignored."""
+    """With tracked_vins set, only that VIN is added, others are ignored."""
     account = SmartAccount(TEST_USERNAME, TEST_PASSWORD, tracked_vins=["TestVIN0000000001"])
     await account.get_vehicles()
     assert set(account.vehicles.keys()) == {"TestVIN0000000001"}

--- a/pysmarthashtag/tests/test_tracked_vins.py
+++ b/pysmarthashtag/tests/test_tracked_vins.py
@@ -1,0 +1,22 @@
+"""Only the configured VIN should be tracked; shared/other cars are ignored."""
+
+import pytest
+
+from pysmarthashtag.account import SmartAccount
+from pysmarthashtag.tests import TEST_PASSWORD, TEST_USERNAME
+
+
+@pytest.mark.asyncio
+async def test_tracked_vins_filters_out_other_vehicles(smart_fixture):
+    """With tracked_vins set, only that VIN is added — others are ignored."""
+    account = SmartAccount(TEST_USERNAME, TEST_PASSWORD, tracked_vins=["TestVIN0000000001"])
+    await account.get_vehicles()
+    assert set(account.vehicles.keys()) == {"TestVIN0000000001"}
+
+
+@pytest.mark.asyncio
+async def test_no_tracked_vins_keeps_all(smart_fixture):
+    """Default (None) preserves the previous all-vehicles behaviour."""
+    account = SmartAccount(TEST_USERNAME, TEST_PASSWORD)
+    await account.get_vehicles()
+    assert "TestVIN0000000002" in account.vehicles

--- a/pysmarthashtag/tests/test_vin_headers.py
+++ b/pysmarthashtag/tests/test_vin_headers.py
@@ -1,0 +1,38 @@
+"""Tests for the per-request X-Vehicle-* binding headers (anti binding-theft)."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from pysmarthashtag.api import utils
+
+_VIN = "TESTVIN123"
+_MODEL = "HX11 EUL/Premium"  # contains chars that must be url-encoded
+
+
+def _hdr(url, vin=None, model_code=None):
+    return utils.generate_default_header(
+        "dev", "tok", params={}, method="GET", url=url, vin=vin, model_code=model_code
+    )
+
+
+def test_vin_headers_added_for_data_request():
+    h = _hdr("/remote-control/vehicle/status/" + _VIN, vin=_VIN, model_code=_MODEL)
+    assert h["X-Vehicle-IDENTIFIER"] == _VIN
+    assert h["X-VEHICLE-SERIES"] == quote(_MODEL, safe="")
+    assert h["X-VEHICLE-MODEL"] == quote(_MODEL, safe="")
+
+
+def test_no_vin_headers_without_vin_or_model():
+    assert "X-Vehicle-IDENTIFIER" not in _hdr("/remote-control/vehicle/status/x")
+    # vin but no model_code -> omitted
+    assert "X-Vehicle-IDENTIFIER" not in _hdr("/remote-control/vehicle/status/x", vin=_VIN)
+    # model_code but no vin -> omitted
+    assert "X-Vehicle-IDENTIFIER" not in _hdr("/remote-control/vehicle/status/x", model_code=_MODEL)
+
+
+def test_vin_headers_skipped_for_blacklisted_endpoints():
+    # session/update (the re-bind) and capability are excluded, matching the app
+    for url in ("/device-platform/user/session/update", "/geelyTCAccess/tcservices/capability/foo"):
+        h = _hdr(url, vin=_VIN, model_code=_MODEL)
+        assert "X-Vehicle-IDENTIFIER" not in h, url


### PR DESCRIPTION
## Summary

Reworks session recovery. Doing a full Gigya re-login for **every** failure
hammers the rate-limited login gateway, and could wedge the Home Assistant
integration into all-sensors-`unavailable` until a manual reload. The SDK now
uses a **layered remedy ladder keyed by the cloud response code**.

> The author is running this live on Home Assistant and will validate
> it for **one week** before calling it a success. Please don't merge yet.

## Problem

The EU login is a multi-step OAuth + Gigya flow. When something goes wrong the
SDK previously did one thing (a full re-login) regardless of cause, and the
comment claimed "refresh token is not implemented". Neither is right:

- The cloud **does** support refreshing the session via `session/secure`.
- `4038`/`8040` (VIN binding issues) can never be fixed by a re-login.
- Collapsing everything into re-login pounds the rate-limited gateway, so a
  transient hiccup snowballs into a wedged, all-`unavailable` integration.

## The remedy ladder (by cloud `code`)

| Code | Meaning | Remedy |
|---|---|---|
| `1402` / `8006` | API session token expired | **Layer 1**: refresh the API session (POST `session/secure` with the stored OAuth token) |
| `1501` | OAuth token expired | **Layer 2**: refresh-token exchange (PUT `session/secure` + `X-CLIENT-ID`), then re-run Layer 1 |
| `4038` | vehicle not in use | **re-bind the VIN** (`session/update`) + retry, *not* a token op |
| `8040` | VIN not bound to account | **terminal** `SmartVehicleUnboundError` (surface; re-login won't help) |
| `1443` / `8160` | nonce repeated / no permission | typed errors |
| *fallback* | | **Layer 3**: full credential re-login, backoff-wrapped |

Layer 1 is cheap and does **not** touch the rate-limited login gateway, so token
expiry no longer triggers login storms.

## Changes

- `api/authentication.py`: `refresh_api_session()` (layer 1),
  `refresh_token_exchange()` (layer 2), and a `refresh()` orchestrator; capture
  `clientId`; broaden rate-limit classification for throttle wording.
- `api/client.py`: map each cloud `code` to a typed exception; the response hook
  no longer logs in inline. The caller decides the remedy.
- `account.py`: session-expiry now calls `refresh()`; `4038` re-binds the VIN
  (also fixes a latent missing-`await` on the existing re-bind path).
- `models.py`: new typed errors (`SmartVehicleNotInUseError`,
  `SmartVehicleUnboundError`, `SmartMainTokenExpiredError`, `SmartNonceError`,
  `SmartNoPermissionError`).
- **176 tests pass** (30 new in `tests/test_token_lifecycle.py`).

## Companion change

A matching PR to the integration (DasBasti/SmartHashtag#448) surfaces
`SmartVehicleUnboundError` as a reauth prompt.

## Trying this branch on Home Assistant

The integration pins a fixed `pysmarthashtag` version, so to run this branch you
build a wheel and point the manifest at it. No SSH-into-the-container needed: HA
**reinstalls any URL requirement on every start**
(`homeassistant/util/package.py::is_installed()` returns `False` for
`@`-reference requirements).

1. **Build a wheel** (Python 3 with `pip`/`setuptools`/`setuptools-scm`; output
   is pure `py3-none-any`):
   ```bash
   git clone -b feat/token-lifecycle https://github.com/chriscatuk/pySmartHashtag
   cd pySmartHashtag
   SETUPTOOLS_SCM_PRETEND_VERSION=0.10.9 python -m pip wheel --no-deps -w dist .
   # -> dist/pysmarthashtag-0.10.9-py3-none-any.whl
   ```
2. **Copy it into your HA config folder** (Samba / SSH / File editor), e.g. `/config/`.
3. **Point the integration at it**, edit
   `/config/custom_components/smarthashtag/manifest.json`:
   ```json
   "requirements": ["pysmarthashtag @ file:///config/pysmarthashtag-0.10.9-py3-none-any.whl"],
   ```
4. **Restart Home Assistant.** On boot HA installs the wheel over the pinned version.
5. **To revert:** set the requirement back to the normal pin and restart.

Notes: the deps (`httpx`, `pycryptodome`, `pyjwt`) are already present, so no
internet is needed; HA Core / venv installs work the same way (only the path to
`/config` differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added optional VIN tracking so only selected vehicles are loaded.
  - Improved Smart API session recovery with layered refresh (refresh → token exchange → re-login fallback).
  - Enhanced per-request VIN/model header handling, including URL-encoded model codes and endpoint-specific header exclusions.

- **Bug Fixes**
  - Improved handling of “vehicle not in use” and “VIN unbound” with safe re-bind and retry (avoids runaway loops).
  - More resilient per-vehicle data collection: failures are isolated and the real error is surfaced after retries.

- **Tests**
  - Added coverage for token lifecycle orchestration, cloud error-code mapping, rate-limit detection, and VIN header/tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

