### PR TITLE
fix(battery): scale DC charging current for Smart #5

### DIFF
--- a/pysmarthashtag/const.py
+++ b/pysmarthashtag/const.py
@@ -17,6 +17,12 @@ API_JOURNAL_TOGGLE_URL = "/remote-control/vehicle/status/journalLog/"
 
 OTA_SERVER_URL = "https://ota.srv.smart.com/"
 
+# Prefixes of the "seriesCodeVs" field identifying the vehicle model. They select
+# the API version to talk to and, for the #5, the scaling of some telemetry fields.
+SERIES_CODE_PREFIX_SMART_1 = "HX"
+SERIES_CODE_PREFIX_SMART_3 = "HC"
+SERIES_CODE_PREFIX_SMART_5 = "HY"
+
 # Gigya socialize endpoint used to bootstrap a Gigya session (gmid + ucid)
 # before posting accounts.login. Smart's tenant rejects accounts.login from
 # a "fresh" client without these identifiers + the gig_bootstrap cookie.

--- a/pysmarthashtag/tests/test_account.py
+++ b/pysmarthashtag/tests/test_account.py
@@ -137,9 +137,11 @@ async def test_get_vehicle_chargin_dc(smart_fixture: respx.Router):
     # TODO: missing 3-phase charging
     assert vehicles["TestVIN0000000002"].battery.charging_status == "DC_CHARGING"
     assert vehicles["TestVIN0000000002"].battery.is_charger_connected
-    assert vehicles["TestVIN0000000002"].battery.charging_current == ValueWithUnit(value=102.6, unit="A")
+    # VIN ...002 has a Smart #5 series code, so the raw "dcChargeIAct" of -102.6 is
+    # read as deci-ampere and scaled down to 10.26 A (issue #459).
+    assert vehicles["TestVIN0000000002"].battery.charging_current == ValueWithUnit(value=10.26, unit="A")
     assert vehicles["TestVIN0000000002"].battery.charging_voltage == ValueWithUnit(value=429, unit="V")
-    assert vehicles["TestVIN0000000002"].battery.charging_power == ValueWithUnit(value=44015, unit="W")
+    assert vehicles["TestVIN0000000002"].battery.charging_power == ValueWithUnit(value=4401, unit="W")
 
 
 @pytest.mark.asyncio

--- a/pysmarthashtag/tests/test_dc_charging.py
+++ b/pysmarthashtag/tests/test_dc_charging.py
@@ -6,13 +6,17 @@ from pysmarthashtag.models import ValueWithUnit
 from pysmarthashtag.vehicle.battery import Battery, ChargingState, DcChargingVoltLevels
 
 
-def create_vehicle_data_with_dc_charging(charge_level: int, dc_charge_current: float) -> dict:
+def create_vehicle_data_with_dc_charging(
+    charge_level: int, dc_charge_current: float, series_code: str = "HX11"
+) -> dict:
     """Create test vehicle data with DC charging parameters.
 
     Args:
     ----
         charge_level: Battery charge level percentage (0-100)
-        dc_charge_current: DC charging current in Amps (negative for charging)
+        dc_charge_current: DC charging current as reported by the API
+            (negative for charging, deci-ampere on the Smart #5)
+        series_code: Value of the "seriesCodeVs" field selecting the vehicle model
 
     Returns:
     -------
@@ -20,6 +24,7 @@ def create_vehicle_data_with_dc_charging(charge_level: int, dc_charge_current: f
 
     """
     return {
+        "seriesCodeVs": series_code,
         "vehicleStatus": {
             "updateTime": "1716485767970",
             "additionalVehicleStatus": {
@@ -36,7 +41,7 @@ def create_vehicle_data_with_dc_charging(charge_level: int, dc_charge_current: f
                     "averPowerConsumption": "-102.3",
                 }
             },
-        }
+        },
     }
 
 
@@ -148,6 +153,69 @@ class TestDcChargingDataHandling:
         assert battery is not None
         assert battery.remaining_range == ValueWithUnit(value=285, unit="km")
         assert battery.remaining_range_at_full_charge == ValueWithUnit(value=427, unit="km")
+
+
+class TestDcChargingSmart5Scaling:
+    """Test that the Smart #5 deci-ampere DC current is scaled down (issue #459)."""
+
+    def test_smart_5_dc_current_is_divided_by_ten(self):
+        """Test that a #5 reporting 1650 deci-ampere yields 165 A instead of 1650 A."""
+        vehicle_data = create_vehicle_data_with_dc_charging(
+            charge_level=55, dc_charge_current=-1650.0, series_code="HY11"
+        )
+        battery = Battery.from_vehicle_data(vehicle_data)
+
+        assert battery is not None
+        assert battery.charging_status == "DC_CHARGING"
+        assert battery.charging_current == ValueWithUnit(value=165.0, unit="A")
+        # Voltage is unaffected by the scaling
+        assert battery.charging_voltage == ValueWithUnit(value=DcChargingVoltLevels[55], unit="V")
+        expected_power = math.floor(165.0 * DcChargingVoltLevels[55])
+        assert battery.charging_power == ValueWithUnit(value=expected_power, unit="W")
+
+    def test_smart_1_dc_current_is_not_scaled(self):
+        """Test that the #1 keeps reporting DC current in ampere."""
+        vehicle_data = create_vehicle_data_with_dc_charging(
+            charge_level=55, dc_charge_current=-165.0, series_code="HX11"
+        )
+        battery = Battery.from_vehicle_data(vehicle_data)
+
+        assert battery is not None
+        assert battery.charging_current == ValueWithUnit(value=165.0, unit="A")
+
+    def test_smart_3_dc_current_is_not_scaled(self):
+        """Test that the #3 keeps reporting DC current in ampere."""
+        vehicle_data = create_vehicle_data_with_dc_charging(
+            charge_level=55, dc_charge_current=-165.0, series_code="HC11"
+        )
+        battery = Battery.from_vehicle_data(vehicle_data)
+
+        assert battery is not None
+        assert battery.charging_current == ValueWithUnit(value=165.0, unit="A")
+
+    def test_missing_series_code_is_not_scaled(self):
+        """Test that data without a series code falls back to the unscaled V1 behaviour."""
+        vehicle_data = create_vehicle_data_with_dc_charging(charge_level=55, dc_charge_current=-165.0)
+        del vehicle_data["seriesCodeVs"]
+        battery = Battery.from_vehicle_data(vehicle_data)
+
+        assert battery is not None
+        assert battery.charging_current == ValueWithUnit(value=165.0, unit="A")
+
+    def test_smart_5_ac_current_is_not_scaled(self):
+        """Test that AC charging on a #5 is passed through unscaled."""
+        vehicle_data = create_vehicle_data_with_dc_charging(charge_level=55, dc_charge_current=0.0, series_code="HY11")
+        evStatus = vehicle_data["vehicleStatus"]["additionalVehicleStatus"]["electricVehicleStatus"]
+        evStatus["chargerState"] = "2"  # CHARGING (AC)
+        evStatus["chargeUAct"] = "230.0"
+        evStatus["chargeIAct"] = "16.000"
+        battery = Battery.from_vehicle_data(vehicle_data)
+
+        assert battery is not None
+        assert battery.charging_status == "CHARGING"
+        assert battery.charging_current == ValueWithUnit(value=16.0, unit="A")
+        assert battery.charging_voltage == ValueWithUnit(value=230.0, unit="V")
+        assert battery.charging_power == ValueWithUnit(value=230.0 * 16.0, unit="W")
 
 
 class TestChargingStateEnum:

--- a/pysmarthashtag/vehicle/battery.py
+++ b/pysmarthashtag/vehicle/battery.py
@@ -6,9 +6,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
+from pysmarthashtag.const import SERIES_CODE_PREFIX_SMART_5
 from pysmarthashtag.models import ValueWithUnit, VehicleDataBase, get_field_as_type
 
 _LOGGER = logging.getLogger(__name__)
+
+"""The V2 API used by the Smart #5 reports "dcChargeIAct" in deci-ampere, while the V1
+API of the #1/#3 reports it in ampere. See SmartHashtag issue #459."""
+DC_CHARGE_CURRENT_DIVIDER_SMART_5 = 10
 
 """Charging state of electric vehicle."""
 ChargingState = [
@@ -236,10 +241,13 @@ class Battery(VehicleDataBase):
                     # Clamp to valid index range: 0 to len(DcChargingVoltLevels) - 1
                     max_index = len(DcChargingVoltLevels) - 1
                     battery_value = max(0, min(battery_value, max_index))
+                    dc_charge_current = abs(dc_charge_i)
+                    if str(vehicle_data.get("seriesCodeVs", "")).startswith(SERIES_CODE_PREFIX_SMART_5):
+                        dc_charge_current /= DC_CHARGE_CURRENT_DIVIDER_SMART_5
                     retval["charging_voltage"] = ValueWithUnit(DcChargingVoltLevels[battery_value], "V")
-                    retval["charging_current"] = ValueWithUnit(abs(dc_charge_i), "A")
+                    retval["charging_current"] = ValueWithUnit(dc_charge_current, "A")
                     retval["charging_power"] = ValueWithUnit(
-                        math.floor(abs(dc_charge_i) * DcChargingVoltLevels[battery_value]),
+                        math.floor(dc_charge_current * DcChargingVoltLevels[battery_value]),
                         "W",
                     )
                 else:

--- a/pysmarthashtag/vehicle/vehicle.py
+++ b/pysmarthashtag/vehicle/vehicle.py
@@ -4,7 +4,13 @@ import datetime
 import logging
 from typing import Optional
 
-from pysmarthashtag.const import API_BASE_URL, API_BASE_URL_V2
+from pysmarthashtag.const import (
+    API_BASE_URL,
+    API_BASE_URL_V2,
+    SERIES_CODE_PREFIX_SMART_1,
+    SERIES_CODE_PREFIX_SMART_3,
+    SERIES_CODE_PREFIX_SMART_5,
+)
 from pysmarthashtag.models import ValueWithUnit, get_element_from_dict_maybe
 from pysmarthashtag.vehicle.battery import Battery
 from pysmarthashtag.vehicle.climate import Climate
@@ -90,13 +96,13 @@ class SmartVehicle:
         self.account = account
         self.data = {}
         self.combine_data(vehicle_base, vehicle_state, charging_settings, None, fetched_at)
-        if self.data["seriesCodeVs"].startswith("HX"):
+        if self.data["seriesCodeVs"].startswith(SERIES_CODE_PREFIX_SMART_1):
             _LOGGER.debug("Selected Vehicle is Smart #1 use V1 API")
             self.base_url = API_BASE_URL
-        elif self.data["seriesCodeVs"].startswith("HC"):
+        elif self.data["seriesCodeVs"].startswith(SERIES_CODE_PREFIX_SMART_3):
             _LOGGER.debug("Selected Vehicle is Smart #3 use V1 API")
             self.base_url = API_BASE_URL
-        elif self.data["seriesCodeVs"].startswith("HY"):
+        elif self.data["seriesCodeVs"].startswith(SERIES_CODE_PREFIX_SMART_5):
             _LOGGER.debug("Selected Vehicle is Smart #5 use V2 API")
             self.base_url = API_BASE_URL_V2
         else:


### PR DESCRIPTION
Fixes DasBasti/SmartHashtag#459

## Problem

On a Smart #5, the DC charging current sensor reads ten times too high, and the derived charging power with it — the reporter saw a plateau of ~1650 A and a peak of 694,512 W where the real values were ~165 A / ~69 kW. AC charging is correct on the same vehicle.

The V2 API used by the #5 reports `dcChargeIAct` in deci-ampere, while the V1 API of the #1/#3 reports it in ampere. `Battery._parse_vehicle_data` passed the raw value straight through for both.

## Change

Divide the DC current by ten when the vehicle's `seriesCodeVs` carries the #5 prefix, and derive `charging_power` from the scaled value:

```python
dc_charge_current = abs(dc_charge_i)
if str(vehicle_data.get("seriesCodeVs", "")).startswith(SERIES_CODE_PREFIX_SMART_5):
    dc_charge_current /= DC_CHARGE_CURRENT_DIVIDER_SMART_5
```

`seriesCodeVs` comes from the vehicle base payload, which `combine_data()` merges into `self.data` before `Battery.from_vehicle_data()` runs and never clears, so it stays available across refreshes. Vehicles with a #1/#3 prefix — and data with no series code at all — keep the previous unscaled behaviour.

The `HX`/`HC`/`HY` prefixes that `vehicle.py` already used to pick the API version move to `const.py` so both call sites share them.

## Tests

New `TestDcChargingSmart5Scaling` covers: #5 scaling with matching power, #1 and #3 left unscaled, missing series code left unscaled, and #5 AC charging unaffected. The existing test helper gained a `series_code` parameter defaulting to `HX11`, so all pre-existing cases are unchanged.

One existing expectation had to move: `test_get_vehicle_chargin_dc` asserted 102.6 A / 44015 W for `TestVIN0000000002`. That VIN was given an `HY11` code in 1d2e97b ("pretend to be Smart #5") purely to exercise the V2 base URL, while its DC payload was captured from a #1 back in 4e1e777. Under the new rule it is a #5, so it now asserts 10.26 A / 4401 W — correct for the fixture as labelled, though not a realistic DC session. If you would rather keep that as a realistic #1 assertion, the alternative is to move the `HY11` code onto a third fixture vehicle.

`192 passed`. `ruff check` / `ruff format` clean on the touched files.

## Note

The scaling is applied to DC current only. The reporter's AC power looked correct in their screenshots, so `chargeUAct`/`chargeIAct` appear unscaled on the #5 — but that is inferred from one AC session, not from a raw payload. Worth confirming if more #5 data shows up.

Users only get the fix once this is released and `SmartHashtag`'s `manifest.json` pin is bumped (currently `pysmarthashtag==0.8.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Smart `#5` DC charging current readings, including proper scaling and charging power calculations.
  * Ensured charging current is reported as a positive value across supported vehicle series.
* **Tests**
  * Added coverage for Smart `#5` scaling, Smart `#1` and Smart `#3` charging, missing series information, and Smart `#5` AC charging.
* **Refactor**
  * Standardized vehicle-series identification for more consistent model handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->